### PR TITLE
wrapped method with nan, and changed argument type in init call

### DIFF
--- a/3_callbacks/nan/addon.cc
+++ b/3_callbacks/nan/addon.cc
@@ -1,14 +1,19 @@
 #include <nan.h>
 
-void RunCallback(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+NAN_METHOD(RunCallback) {
   v8::Local<v8::Function> cb = info[0].As<v8::Function>();
   const unsigned argc = 1;
-  v8::Local<v8::Value> argv[argc] = { Nan::New("hello world").ToLocalChecked() };
-  Nan::MakeCallback(Nan::GetCurrentContext()->Global(), cb, argc, argv);
+  v8::Local<v8::Value> argv[argc] = { Nan::New<v8::String>("hello world").ToLocalChecked() };
+  Nan::MakeCallback(info.This(), cb, argc, argv);
+
+  info.GetReturnValue().SetUndefined();
 }
 
-void Init(v8::Local<v8::Object> exports, v8::Local<v8::Object> module) {
-  Nan::SetMethod(module, "exports", RunCallback);
+void Init(v8::Handle<v8::Object> exports, v8::Handle<v8::Object> module) {
+  Nan::SetMethod(module
+    , "exports"
+    , RunCallback
+  );
 }
 
 NODE_MODULE(addon, Init)


### PR DESCRIPTION
updated 3rd example with nan method wrapper, and changed arguments in init function.

it would be nice if we can change this example all together, to use init wrapper, because target argument depends on this condition in nan

``` cpp
#if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
  typedef v8::Handle<v8::Object> ADDON_REGISTER_FUNCTION_ARGS_TYPE;
#else
  typedef v8::Local<v8::Object> ADDON_REGISTER_FUNCTION_ARGS_TYPE;
#endif
```

but that would mean that you won't be able to do this in javascript:

``` javascript
var addon = require('bindings')('addon');

addon(function(msg){
  console.log(msg); // 'hello world'
});
```

but instead would have to expose your method by name, which would lead to this:

``` javascript
addon.myMethodName(function(msg){
//...
});
```

but this type of example would be more portable in my opinion.
