### PR TITLE
example of code coverage

### DIFF
--- a/X_coverage/.gitignore
+++ b/X_coverage/.gitignore
@@ -1,0 +1,1 @@
+coverage/

--- a/X_coverage/README.md
+++ b/X_coverage/README.md
@@ -1,0 +1,44 @@
+## Example X: *code coverage*
+
+The example shows how to gather coverage of the c++ code while running
+javascript tests.
+
+It uses facilities built into gcc to measure the coverage, and the `lcov` tool
+to make those measurements easy to read.
+
+
+### Rerequisites
+
+#### npm dependencies
+Run `npm install` to install the npm packages for this example.
+
+#### lcov
+On Mac OS you can use something like [homebrew][] to install the `lcov`
+package. On linux you can use the appropriate package manager (yum, apt-get,
+etc) to install it.
+
+
+### Run the Example
+Simple do an `npm run-script coverage` to build the binary with coverage
+instrumentation, run the tests, and gather the coverage results.
+
+
+### How It Works
+There are more details in the comments of `binding.gyp` and `test/coverage.sh`
+but here is the basic approach:
+
+1. build the binary with coverage
+    * `gcc` has a `--coverage` flag which will cause the binary to log
+      coverage measurements as it is being run.
+2. generate coverage measurements
+    * While running our tests (`test/addon.js`) the instrumentation built into
+      the binary will cause a `build/Debug/obj.target/addon/addon.gcda` to be
+      created which contains a log of lines which have been executed.
+3. format the results
+    * The `.gcda` file is a binary format so we need to process it so that we
+      can understand the results. The `lcov` tool is used to do that. It has
+      an `lcov` command for processing and a `genhtml` command to create HTML
+      output.
+
+
+[homebrew]: http://brew.sh

--- a/X_coverage/addon.cc
+++ b/X_coverage/addon.cc
@@ -1,0 +1,30 @@
+// This is a copy of the 2_function_arguments example. Our unit tests in
+// `test/addon.js` will exercise this code.
+
+#include <nan.h>
+
+void Add(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+
+  if (info.Length() < 2) {
+    Nan::ThrowTypeError("Wrong number of arguments");
+    return;
+  }
+
+  if (!info[0]->IsNumber() || !info[1]->IsNumber()) {
+    Nan::ThrowTypeError("Wrong arguments");
+    return;
+  }
+
+  double arg0 = info[0]->NumberValue();
+  double arg1 = info[1]->NumberValue();
+  v8::Local<v8::Number> num = Nan::New(arg0 + arg1);
+
+  info.GetReturnValue().Set(num);
+}
+
+void Init(v8::Local<v8::Object> exports) {
+  exports->Set(Nan::New("add").ToLocalChecked(),
+               Nan::New<v8::FunctionTemplate>(Add)->GetFunction());
+}
+
+NODE_MODULE(addon, Init)

--- a/X_coverage/binding.gyp
+++ b/X_coverage/binding.gyp
@@ -1,0 +1,40 @@
+{
+  # This defines a variable which we can pass along to node-gyp as an
+  # argument. For example:  node-gyp build --coverage=true
+  "variables": {
+    "coverage": "false"
+  },
+  "targets": [
+    {
+      "target_name": "addon",
+      "sources": [ "addon.cc" ],
+      "include_dirs": [
+        "<!(node -e \"require('nan')\")"
+      ],
+      "conditions": [
+        [
+          "coverage == 'true' and OS == 'mac'",
+          {
+            "xcode_settings": {
+              # We need to pass this flag in both places since the compile and
+              # link phases are run separately. See `man gcc` for details on
+              # what this flag does during each phase.
+              "OTHER_CFLAGS+": [ "--coverage" ],
+              "OTHER_LDFLAGS+": [ "--coverage" ]
+            }
+          }
+        ],
+        [
+          "coverage == 'true' and OS == 'linux'",
+          {
+            # We need to pass this flag in both places since the compile and
+            # link phases are run separately. See `man gcc` for details on
+            # what this flag does during each phase.
+            "cflags+": [ "--coverage" ],
+            "ldflags+": [ "--coverage" ]
+          }
+        ]
+      ]
+    }
+  ]
+}

--- a/X_coverage/package.json
+++ b/X_coverage/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "code_coverage",
+  "version": "0.0.0",
+  "description": "Node.js Addons Example of Binary Code Coverage",
+  "main": "addon.js",
+  "private": true,
+  "dependencies": {
+    "bindings": "~1.2.1",
+    "nan": "^2.0.0"
+  },
+  "devDependencies": {
+    "mocha": "^2.2.5",
+    "node-gyp": "^2.0.2"
+  },
+  "scripts": {
+    "coverage": "test/coverage.sh",
+    "test": "mocha test/addon.js"
+  },
+  "gypfile": true
+}

--- a/X_coverage/test/addon.js
+++ b/X_coverage/test/addon.js
@@ -1,0 +1,16 @@
+var addon = require('bindings')('addon.node'),
+    assert = require('assert');
+
+describe('add()', function() {
+  it('should add two arguments', function() {
+    assert.equal(addon.add(3, 5), 8);
+  });
+  it('should ignore extra arguments', function() {
+    assert.equal(addon.add(3, 5, 7, 9), 8);
+  });
+  it('should throw if not enough arguments', function() {
+    assert.throws(function() {
+      addon.add(3);
+    }, Error);
+  });
+});

--- a/X_coverage/test/coverage.sh
+++ b/X_coverage/test/coverage.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# For this example we'll just use `coverage/` but it can be anything you want.
+COVERAGE_DIR=coverage
+
+# Stop this script if any command fails.
+set -e
+
+# Reset the coverage directory.
+rm -rf $COVERAGE_DIR
+mkdir -p $COVERAGE_DIR
+
+# Build the binary with coverage instrumentation built into it.
+# See binding.gyp for details on how the --coverage flag is used.
+node-gyp rebuild --debug --coverage=true
+
+# Run the tests. The instrumentation built into the binary will cause a
+# `build/Debug/obj.target/addon/addon.gcda` to be created, which contains the
+# coverage measurements.
+node_modules/.bin/mocha test/addon.js
+
+# Turn the binary `*.gcda` file into a standard `lcov.info` text file.
+lcov --capture --directory build --output-file $COVERAGE_DIR/lcov.info
+
+# Strip out coverage measurements for things which are not our code.
+lcov --remove $COVERAGE_DIR/lcov.info \
+  "/usr/*" \
+  "node_modules/*" \
+  "v8/include/*" \
+  --output-file $COVERAGE_DIR/lcov.info
+
+# Print coverage summary to STDOUT, which is nice quick feedback.
+lcov --list $COVERAGE_DIR/lcov.info
+
+# Create the HTML files with details of coverage measurements.
+genhtml --output-directory $COVERAGE_DIR/lcov-report $COVERAGE_DIR/lcov.info
+
+echo
+echo "open $COVERAGE_DIR/lcov-report/index.html in a browser for coverage details"
+


### PR DESCRIPTION
This is a separate example that shows how to collect coverage of the c++
code. Since the purpose is to demonstrate a _build_ technique (not a coding
technique) I just used the nan API for simplicity.

This PR will likely need some refinement to fit well with this repository.
