### PR TITLE
Updated Readme, coming soon example for V4 & V5

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Each directory contains a subdirectory for:
 * **Node 0.10**: Mostly compatible with Node 0.8 and even 0.6, older style V8 programming
 * **Node 0.12**: Newer style V8 programming, compatible with Node 0.11+
 * **NAN**: The example rewritten using [NAN](https://github.com/rvagg/nan/) for compatibility with Node 0.8 -> 0.11+
- **V5**
+
 
 You will need [node-gyp](https://github.com/TooTallNate/node-gyp/) installed as a global:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 Node.js Addon Examples
 ======================
 
+
+ **Coming soon**, we are refreshing the examples to run on  **V4** &  **V5** of Node.js
+
+
 See the Node.js C++ [addons page](http://nodejs.org/docs/latest/api/addons.html) for details of the examples here.
 
 Each directory contains a subdirectory for:
@@ -8,6 +12,7 @@ Each directory contains a subdirectory for:
 * **Node 0.10**: Mostly compatible with Node 0.8 and even 0.6, older style V8 programming
 * **Node 0.12**: Newer style V8 programming, compatible with Node 0.11+
 * **NAN**: The example rewritten using [NAN](https://github.com/rvagg/nan/) for compatibility with Node 0.8 -> 0.11+
+ **V5**
 
 You will need [node-gyp](https://github.com/TooTallNate/node-gyp/) installed as a global:
 


### PR DESCRIPTION
I updated the README.md letting users of node-addon-examples know that updates are coming soon of node-addon-examples running on v4 or v5. I also read that maybe v4 & v5 should be the same, since everything isn't quite written in stone on how were gonna do it. I just thought it important to let people know that an update is coming. 
