### PR TITLE
Add CMake.js support and use NAN shorthands

### DIFF
--- a/1_hello_world/nan_cmake-js/CMakeLists.txt
+++ b/1_hello_world/nan_cmake-js/CMakeLists.txt
@@ -1,0 +1,21 @@
+# https://github.com/cmake-js/cmake-js/wiki/TUTORIAL-01-Creating-a-native-module-by-using-CMake.js-and-NAN
+
+cmake_minimum_required(VERSION 2.8)
+
+# Name of the project (will be the name of the plugin)
+project(addon)
+
+# Build a shared library from the C++ files
+set(SOURCE_FILES addon.cpp)
+add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
+
+# Gives our library file a .node extension without any "lib" prefix
+set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "" SUFFIX ".node")
+
+# Essential include files to build a node addon,
+# You should add this line in every CMake.js based project
+target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_JS_INC})
+
+# Essential library files to link to a node addon
+# You should add this line in every CMake.js based project
+target_link_libraries(${PROJECT_NAME} ${CMAKE_JS_LIB})

--- a/1_hello_world/nan_cmake-js/addon.cpp
+++ b/1_hello_world/nan_cmake-js/addon.cpp
@@ -1,0 +1,12 @@
+#include <nan.h>
+
+void Method(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  info.GetReturnValue().Set(Nan::New("world").ToLocalChecked());
+}
+
+void Init(v8::Local<v8::Object> exports) {
+  exports->Set(Nan::New("hello").ToLocalChecked(),
+               Nan::New<v8::FunctionTemplate>(Method)->GetFunction());
+}
+
+NODE_MODULE(hello, Init)

--- a/1_hello_world/nan_cmake-js/addon.cpp
+++ b/1_hello_world/nan_cmake-js/addon.cpp
@@ -1,12 +1,24 @@
+
+// based on https://github.com/fcanas/node-native-boilerplate
+
 #include <nan.h>
 
-void Method(const Nan::FunctionCallbackInfo<v8::Value>& info) {
-  info.GetReturnValue().Set(Nan::New("world").ToLocalChecked());
+// method declaration + definition
+
+NAN_METHOD(sayHello);  // this should go into a header file
+
+NAN_METHOD(sayHello)   // and this should be in a separate source file
+{
+    info.GetReturnValue().Set(Nan::New("Hello world!").ToLocalChecked());
 }
 
-void Init(v8::Local<v8::Object> exports) {
-  exports->Set(Nan::New("hello").ToLocalChecked(),
-               Nan::New<v8::FunctionTemplate>(Method)->GetFunction());
+// module initialization
+
+NAN_MODULE_INIT(init)
+{
+    Nan::Set(target,
+             Nan::New("sayHello").ToLocalChecked(),
+             Nan::GetFunction(Nan::New<v8::FunctionTemplate>(sayHello)).ToLocalChecked());
 }
 
-NODE_MODULE(hello, Init)
+NODE_MODULE(addon, init)

--- a/1_hello_world/nan_cmake-js/package.json
+++ b/1_hello_world/nan_cmake-js/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "hello_world",
+  "version": "0.0.0",
+  "description": "Node.js Addons Example #1",
+  "private": true,
+  "main": "test.js",
+  "scripts": {
+    "build": "cmake-js build",
+    "rebuild": "cmake-js rebuild",
+    "test": "node test.js"
+  },
+  "dependencies": {
+    "bindings": "^1.2.1"
+  },
+  "devDependencies": {
+    "cmake-js": "^3.1.2",
+    "nan": "^2.2.1"
+  }
+}

--- a/1_hello_world/nan_cmake-js/test.js
+++ b/1_hello_world/nan_cmake-js/test.js
@@ -1,3 +1,4 @@
+
 var addon = require('bindings')('addon');
 
-console.log(addon.hello()); // 'world'
+console.log(addon.sayHello());  // 'Hello world!'

--- a/1_hello_world/nan_cmake-js/test.js
+++ b/1_hello_world/nan_cmake-js/test.js
@@ -1,0 +1,3 @@
+var addon = require('bindings')('addon');
+
+console.log(addon.hello()); // 'world'

--- a/2_function_arguments/nan_cmake-js/CMakeLists.txt
+++ b/2_function_arguments/nan_cmake-js/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(addon)
+
+set(SOURCE_FILES addon.cpp)
+
+add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
+set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "" SUFFIX ".node")
+target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_JS_INC})
+target_link_libraries(${PROJECT_NAME} ${CMAKE_JS_LIB})

--- a/2_function_arguments/nan_cmake-js/addon.cpp
+++ b/2_function_arguments/nan_cmake-js/addon.cpp
@@ -1,0 +1,27 @@
+#include <nan.h>
+
+void Add(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+
+  if (info.Length() < 2) {
+    Nan::ThrowTypeError("Wrong number of arguments");
+    return;
+  }
+
+  if (!info[0]->IsNumber() || !info[1]->IsNumber()) {
+    Nan::ThrowTypeError("Wrong arguments");
+    return;
+  }
+
+  double arg0 = info[0]->NumberValue();
+  double arg1 = info[1]->NumberValue();
+  v8::Local<v8::Number> num = Nan::New(arg0 + arg1);
+
+  info.GetReturnValue().Set(num);
+}
+
+void Init(v8::Local<v8::Object> exports) {
+  exports->Set(Nan::New("add").ToLocalChecked(),
+               Nan::New<v8::FunctionTemplate>(Add)->GetFunction());
+}
+
+NODE_MODULE(addon, Init)

--- a/2_function_arguments/nan_cmake-js/addon.cpp
+++ b/2_function_arguments/nan_cmake-js/addon.cpp
@@ -1,27 +1,40 @@
+
 #include <nan.h>
 
-void Add(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+NAN_METHOD(add)
+{
+    if (info.Length() != 2)
+    {
+        Nan::ThrowTypeError("Wrong number of arguments");
+        return;
+    }
+    // @see https://v8docs.nodesource.com/node-5.0/dc/d0a/classv8_1_1_value.html
+    if (!info[0]->IsNumber() || !info[1]->IsNumber())
+    {
+        Nan::ThrowTypeError("Wrong argument types");
+        return;
+    }
 
-  if (info.Length() < 2) {
-    Nan::ThrowTypeError("Wrong number of arguments");
-    return;
-  }
+    // get the arguments and compute the result
+    // @see https://v8docs.nodesource.com/node-5.0/dc/d0a/classv8_1_1_value.html
+    double arg0 = info[0]->NumberValue();
+    double arg1 = info[1]->NumberValue();
+    v8::Local<v8::Number> num = Nan::New(arg0 + arg1);
 
-  if (!info[0]->IsNumber() || !info[1]->IsNumber()) {
-    Nan::ThrowTypeError("Wrong arguments");
-    return;
-  }
+    // in C++11, the return type can be deduced by the compiler
+    // @see https://github.com/nodejs/nan/blob/master/doc%2Fnew.md#nannew
+    // auto num = Nan::New(arg0 + arg1);
 
-  double arg0 = info[0]->NumberValue();
-  double arg1 = info[1]->NumberValue();
-  v8::Local<v8::Number> num = Nan::New(arg0 + arg1);
-
-  info.GetReturnValue().Set(num);
+    info.GetReturnValue().Set(num);
 }
 
-void Init(v8::Local<v8::Object> exports) {
-  exports->Set(Nan::New("add").ToLocalChecked(),
-               Nan::New<v8::FunctionTemplate>(Add)->GetFunction());
+// module initialization
+
+NAN_MODULE_INIT(init)
+{
+    Nan::Set(target,
+             Nan::New("add").ToLocalChecked(),
+             Nan::GetFunction(Nan::New<v8::FunctionTemplate>(add)).ToLocalChecked());
 }
 
-NODE_MODULE(addon, Init)
+NODE_MODULE(addon, init)

--- a/2_function_arguments/nan_cmake-js/package.json
+++ b/2_function_arguments/nan_cmake-js/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "function_arguments",
+  "version": "0.0.0",
+  "description": "Node.js Addons Example #2",
+  "private": true,
+  "main": "test.js",
+  "scripts": {
+    "build": "cmake-js build",
+    "rebuild": "cmake-js rebuild",
+    "test": "node test.js"
+  },
+  "dependencies": {
+    "bindings": "^1.2.1"
+  },
+  "devDependencies": {
+    "cmake-js": "^3.1.2",
+    "nan": "^2.2.1"
+  }
+}

--- a/2_function_arguments/nan_cmake-js/test.js
+++ b/2_function_arguments/nan_cmake-js/test.js
@@ -1,0 +1,3 @@
+var addon = require('bindings')('addon')
+
+console.log('This should be eight:', addon.add(3, 5))

--- a/2_function_arguments/nan_cmake-js/test.js
+++ b/2_function_arguments/nan_cmake-js/test.js
@@ -1,3 +1,4 @@
+
 var addon = require('bindings')('addon')
 
 console.log('This should be eight:', addon.add(3, 5))

--- a/3_callbacks/nan_cmake-js/CMakeLists.txt
+++ b/3_callbacks/nan_cmake-js/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(addon)
+
+set(SOURCE_FILES addon.cpp)
+
+add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
+set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "" SUFFIX ".node")
+target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_JS_INC})
+target_link_libraries(${PROJECT_NAME} ${CMAKE_JS_LIB})

--- a/3_callbacks/nan_cmake-js/addon.cpp
+++ b/3_callbacks/nan_cmake-js/addon.cpp
@@ -1,0 +1,14 @@
+#include <nan.h>
+
+void RunCallback(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  v8::Local<v8::Function> cb = info[0].As<v8::Function>();
+  const unsigned argc = 1;
+  v8::Local<v8::Value> argv[argc] = { Nan::New("hello world").ToLocalChecked() };
+  Nan::MakeCallback(Nan::GetCurrentContext()->Global(), cb, argc, argv);
+}
+
+void Init(v8::Local<v8::Object> exports, v8::Local<v8::Object> module) {
+  Nan::SetMethod(module, "exports", RunCallback);
+}
+
+NODE_MODULE(addon, Init)

--- a/3_callbacks/nan_cmake-js/addon.cpp
+++ b/3_callbacks/nan_cmake-js/addon.cpp
@@ -1,14 +1,39 @@
+
 #include <nan.h>
 
-void RunCallback(const Nan::FunctionCallbackInfo<v8::Value>& info) {
-  v8::Local<v8::Function> cb = info[0].As<v8::Function>();
-  const unsigned argc = 1;
-  v8::Local<v8::Value> argv[argc] = { Nan::New("hello world").ToLocalChecked() };
-  Nan::MakeCallback(Nan::GetCurrentContext()->Global(), cb, argc, argv);
+NAN_METHOD(runCallback)
+{
+    if (info.Length() != 1)
+    {
+        Nan::ThrowTypeError("Wrong number of arguments");
+        return;
+    }
+    if (!info[0]->IsFunction())
+    {
+        Nan::ThrowTypeError("Wrong argument type");
+        return;
+    }
+
+    // prepare the callback function and its arguments
+    v8::Local<v8::Function> callbackFunction = info[0].As<v8::Function>();
+    const unsigned argc = 1;
+    v8::Local<v8::Value> argv[argc] = {
+        Nan::New("Hello world!").ToLocalChecked()
+    };
+
+    Nan::MakeCallback(Nan::GetCurrentContext()->Global(),
+                      callbackFunction,
+                      argc,
+                      argv);
 }
 
-void Init(v8::Local<v8::Object> exports, v8::Local<v8::Object> module) {
-  Nan::SetMethod(module, "exports", RunCallback);
+// module initialization
+
+NAN_MODULE_INIT(init)
+{
+    Nan::Set(target,
+             Nan::New("runCallback").ToLocalChecked(),
+             Nan::GetFunction(Nan::New<v8::FunctionTemplate>(runCallback)).ToLocalChecked());
 }
 
-NODE_MODULE(addon, Init)
+NODE_MODULE(addon, init)

--- a/3_callbacks/nan_cmake-js/package.json
+++ b/3_callbacks/nan_cmake-js/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "callbacks",
+  "version": "0.0.0",
+  "description": "Node.js Addons Example #3",
+  "private": true,
+  "main": "test.js",
+  "scripts": {
+    "build": "cmake-js build",
+    "rebuild": "cmake-js rebuild",
+    "test": "node test.js"
+  },
+  "dependencies": {
+    "bindings": "^1.2.1"
+  },
+  "devDependencies": {
+    "cmake-js": "^3.1.2",
+    "nan": "^2.2.1"
+  }
+}

--- a/3_callbacks/nan_cmake-js/test.js
+++ b/3_callbacks/nan_cmake-js/test.js
@@ -1,0 +1,5 @@
+var addon = require('bindings')('addon');
+
+addon(function(msg){
+  console.log(msg); // 'hello world'
+});

--- a/3_callbacks/nan_cmake-js/test.js
+++ b/3_callbacks/nan_cmake-js/test.js
@@ -1,5 +1,6 @@
+
 var addon = require('bindings')('addon');
 
-addon(function(msg){
-  console.log(msg); // 'hello world'
+addon.runCallback(function(msg) {
+    console.log(msg);  // 'Hello world!'
 });

--- a/4_object_factory/nan_cmake-js/CMakeLists.txt
+++ b/4_object_factory/nan_cmake-js/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(addon)
+
+set(SOURCE_FILES addon.cpp)
+
+add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
+set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "" SUFFIX ".node")
+target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_JS_INC})
+target_link_libraries(${PROJECT_NAME} ${CMAKE_JS_LIB})

--- a/4_object_factory/nan_cmake-js/addon.cpp
+++ b/4_object_factory/nan_cmake-js/addon.cpp
@@ -1,0 +1,15 @@
+#include <nan.h>
+
+void CreateObject(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  v8::Local<v8::Object> obj = Nan::New<v8::Object>();
+  obj->Set(Nan::New("msg").ToLocalChecked(), info[0]->ToString());
+
+  info.GetReturnValue().Set(obj);
+}
+
+void Init(v8::Local<v8::Object> exports, v8::Local<v8::Object> module) {
+  module->Set(Nan::New("exports").ToLocalChecked(),
+      Nan::New<v8::FunctionTemplate>(CreateObject)->GetFunction());
+}
+
+NODE_MODULE(addon, Init)

--- a/4_object_factory/nan_cmake-js/addon.cpp
+++ b/4_object_factory/nan_cmake-js/addon.cpp
@@ -1,15 +1,34 @@
+
 #include <nan.h>
 
-void CreateObject(const Nan::FunctionCallbackInfo<v8::Value>& info) {
-  v8::Local<v8::Object> obj = Nan::New<v8::Object>();
-  obj->Set(Nan::New("msg").ToLocalChecked(), info[0]->ToString());
+NAN_METHOD(createObject)
+{
+    if (info.Length() != 1)
+    {
+        Nan::ThrowTypeError("Wrong number of arguments");
+        return;
+    }
+    if (!info[0]->IsString())
+    {
+        Nan::ThrowTypeError("Wrong argument type");
+        return;
+    }
 
-  info.GetReturnValue().Set(obj);
+    // create an object and add attributes to it
+    v8::Local<v8::Object> obj = Nan::New<v8::Object>();
+    obj->Set(Nan::New("msg").ToLocalChecked(),
+             info[0]->ToString());
+
+    info.GetReturnValue().Set(obj);
 }
 
-void Init(v8::Local<v8::Object> exports, v8::Local<v8::Object> module) {
-  module->Set(Nan::New("exports").ToLocalChecked(),
-      Nan::New<v8::FunctionTemplate>(CreateObject)->GetFunction());
+// module initialization
+
+NAN_MODULE_INIT(init)
+{
+    Nan::Set(target,
+             Nan::New("createObject").ToLocalChecked(),
+             Nan::GetFunction(Nan::New<v8::FunctionTemplate>(createObject)).ToLocalChecked());
 }
 
-NODE_MODULE(addon, Init)
+NODE_MODULE(addon, init)

--- a/4_object_factory/nan_cmake-js/package.json
+++ b/4_object_factory/nan_cmake-js/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "object_factory",
+  "version": "0.0.0",
+  "description": "Node.js Addons Example #4",
+  "private": true,
+  "main": "test.js",
+  "scripts": {
+    "build": "cmake-js build",
+    "rebuild": "cmake-js rebuild",
+    "test": "node test.js"
+  },
+  "dependencies": {
+    "bindings": "^1.2.1"
+  },
+  "devDependencies": {
+    "cmake-js": "^3.1.2",
+    "nan": "^2.2.1"
+  }
+}

--- a/4_object_factory/nan_cmake-js/test.js
+++ b/4_object_factory/nan_cmake-js/test.js
@@ -1,0 +1,5 @@
+var addon = require('bindings')('addon');
+
+var obj1 = addon('hello');
+var obj2 = addon('world');
+console.log(obj1.msg+' '+obj2.msg); // 'hello world'

--- a/4_object_factory/nan_cmake-js/test.js
+++ b/4_object_factory/nan_cmake-js/test.js
@@ -1,5 +1,7 @@
+
 var addon = require('bindings')('addon');
 
-var obj1 = addon('hello');
-var obj2 = addon('world');
-console.log(obj1.msg+' '+obj2.msg); // 'hello world'
+var obj1 = addon.createObject('Hello');
+var obj2 = addon.createObject('world');
+
+console.log(obj1.msg + ' ' + obj2.msg + '!');  // 'Hello world!'

--- a/5_function_factory/nan_cmake-js/CMakeLists.txt
+++ b/5_function_factory/nan_cmake-js/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(addon)
+
+set(SOURCE_FILES addon.cpp)
+
+add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
+set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "" SUFFIX ".node")
+target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_JS_INC})
+target_link_libraries(${PROJECT_NAME} ${CMAKE_JS_LIB})

--- a/5_function_factory/nan_cmake-js/addon.cpp
+++ b/5_function_factory/nan_cmake-js/addon.cpp
@@ -1,0 +1,21 @@
+#include <nan.h>
+
+void MyFunction(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  info.GetReturnValue().Set(Nan::New("hello world").ToLocalChecked());
+}
+
+void CreateFunction(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(MyFunction);
+  v8::Local<v8::Function> fn = tpl->GetFunction();
+
+  // omit this to make it anonymous
+  fn->SetName(Nan::New("theFunction").ToLocalChecked());
+
+  info.GetReturnValue().Set(fn);
+}
+
+void Init(v8::Local<v8::Object> exports, v8::Local<v8::Object> module) {
+  Nan::SetMethod(module, "exports", CreateFunction);
+}
+
+NODE_MODULE(addon, Init)

--- a/5_function_factory/nan_cmake-js/addon.cpp
+++ b/5_function_factory/nan_cmake-js/addon.cpp
@@ -1,21 +1,33 @@
+
 #include <nan.h>
 
-void MyFunction(const Nan::FunctionCallbackInfo<v8::Value>& info) {
-  info.GetReturnValue().Set(Nan::New("hello world").ToLocalChecked());
+NAN_METHOD(myFunction);      ///< the function to be instantiated
+NAN_METHOD(createFunction);  ///< the function factory
+
+NAN_METHOD(myFunction)
+{
+    info.GetReturnValue().Set(Nan::New("Hello world!").ToLocalChecked());
 }
 
-void CreateFunction(const Nan::FunctionCallbackInfo<v8::Value>& info) {
-  v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(MyFunction);
-  v8::Local<v8::Function> fn = tpl->GetFunction();
+NAN_METHOD(createFunction)
+{
+    // create a new function from myFunction's template
+    v8::Local<v8::FunctionTemplate> functionTemplate = Nan::New<v8::FunctionTemplate>(myFunction);
+    v8::Local<v8::Function> functionInstance = functionTemplate->GetFunction();
 
-  // omit this to make it anonymous
-  fn->SetName(Nan::New("theFunction").ToLocalChecked());
+    // omit this to make it anonymous
+    functionInstance->SetName(Nan::New("theFunction").ToLocalChecked());
 
-  info.GetReturnValue().Set(fn);
+    info.GetReturnValue().Set(functionInstance);
 }
 
-void Init(v8::Local<v8::Object> exports, v8::Local<v8::Object> module) {
-  Nan::SetMethod(module, "exports", CreateFunction);
+// module initialization
+
+NAN_MODULE_INIT(init)
+{
+    Nan::Set(target,
+             Nan::New("createFunction").ToLocalChecked(),
+             Nan::GetFunction(Nan::New<v8::FunctionTemplate>(createFunction)).ToLocalChecked());
 }
 
-NODE_MODULE(addon, Init)
+NODE_MODULE(addon, init)

--- a/5_function_factory/nan_cmake-js/package.json
+++ b/5_function_factory/nan_cmake-js/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "function_factory",
+  "version": "0.0.0",
+  "description": "Node.js Addons Example #5",
+  "private": true,
+  "main": "test.js",
+  "scripts": {
+    "build": "cmake-js build",
+    "rebuild": "cmake-js rebuild",
+    "test": "node test.js"
+  },
+  "dependencies": {
+    "bindings": "^1.2.1"
+  },
+  "devDependencies": {
+    "cmake-js": "^3.1.2",
+    "nan": "^2.2.1"
+  }
+}

--- a/5_function_factory/nan_cmake-js/test.js
+++ b/5_function_factory/nan_cmake-js/test.js
@@ -1,0 +1,4 @@
+var addon = require('bindings')('addon');
+
+var fn = addon();
+console.log(fn()); // 'hello world'

--- a/5_function_factory/nan_cmake-js/test.js
+++ b/5_function_factory/nan_cmake-js/test.js
@@ -1,4 +1,5 @@
+
 var addon = require('bindings')('addon');
 
-var fn = addon();
-console.log(fn()); // 'hello world'
+var fn = addon.createFunction();
+console.log(fn());  // 'Hello world!'

--- a/6_object_wrap/nan_cmake-js/CMakeLists.txt
+++ b/6_object_wrap/nan_cmake-js/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(addon)
+
+set(SOURCE_FILES addon.cpp
+                 myobject.cpp
+                 myobject.hpp)
+
+add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
+set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "" SUFFIX ".node")
+target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_JS_INC})
+target_link_libraries(${PROJECT_NAME} ${CMAKE_JS_LIB})

--- a/6_object_wrap/nan_cmake-js/addon.cpp
+++ b/6_object_wrap/nan_cmake-js/addon.cpp
@@ -1,0 +1,8 @@
+#include <nan.h>
+#include "myobject.hpp"
+
+void InitAll(v8::Local<v8::Object> exports) {
+  MyObject::Init(exports);
+}
+
+NODE_MODULE(addon, InitAll)

--- a/6_object_wrap/nan_cmake-js/addon.cpp
+++ b/6_object_wrap/nan_cmake-js/addon.cpp
@@ -1,8 +1,18 @@
+
+// based on:
+// https://github.com/fcanas/node-native-boilerplate
+// https://github.com/nodejs/nan/blob/master/doc/object_wrappers.md
+
 #include <nan.h>
+
 #include "myobject.hpp"
 
-void InitAll(v8::Local<v8::Object> exports) {
-  MyObject::Init(exports);
+// module initialization
+
+NAN_MODULE_INIT(init)
+{
+    // passing target down to the next NAN_MODULE_INIT
+    MyObject::init(target);
 }
 
-NODE_MODULE(addon, InitAll)
+NODE_MODULE(addon, init)

--- a/6_object_wrap/nan_cmake-js/myobject.cpp
+++ b/6_object_wrap/nan_cmake-js/myobject.cpp
@@ -1,0 +1,65 @@
+#include "myobject.hpp"
+
+Nan::Persistent<v8::Function> MyObject::constructor;
+
+MyObject::MyObject(double value) : value_(value) {
+}
+
+MyObject::~MyObject() {
+}
+
+void MyObject::Init(v8::Local<v8::Object> exports) {
+  Nan::HandleScope scope;
+
+  // Prepare constructor template
+  v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
+  tpl->SetClassName(Nan::New("MyObject").ToLocalChecked());
+  tpl->InstanceTemplate()->SetInternalFieldCount(1);
+
+  // Prototype
+  Nan::SetPrototypeMethod(tpl, "value", GetValue);
+  Nan::SetPrototypeMethod(tpl, "plusOne", PlusOne);
+  Nan::SetPrototypeMethod(tpl, "multiply", Multiply);
+
+  constructor.Reset(tpl->GetFunction());
+  exports->Set(Nan::New("MyObject").ToLocalChecked(), tpl->GetFunction());
+}
+
+void MyObject::New(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  if (info.IsConstructCall()) {
+    // Invoked as constructor: `new MyObject(...)`
+    double value = info[0]->IsUndefined() ? 0 : info[0]->NumberValue();
+    MyObject* obj = new MyObject(value);
+    obj->Wrap(info.This());
+    info.GetReturnValue().Set(info.This());
+  } else {
+    // Invoked as plain function `MyObject(...)`, turn into construct call.
+    const int argc = 1;
+    v8::Local<v8::Value> argv[argc] = { info[0] };
+    v8::Local<v8::Function> cons = Nan::New<v8::Function>(constructor);
+    info.GetReturnValue().Set(cons->NewInstance(argc, argv));
+  }
+}
+
+void MyObject::GetValue(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  MyObject* obj = ObjectWrap::Unwrap<MyObject>(info.Holder());
+  info.GetReturnValue().Set(Nan::New(obj->value_));
+}
+
+void MyObject::PlusOne(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  MyObject* obj = ObjectWrap::Unwrap<MyObject>(info.Holder());
+  obj->value_ += 1;
+  info.GetReturnValue().Set(Nan::New(obj->value_));
+}
+
+void MyObject::Multiply(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  MyObject* obj = ObjectWrap::Unwrap<MyObject>(info.Holder());
+  double multiple = info[0]->IsUndefined() ? 1 : info[0]->NumberValue();
+
+  v8::Local<v8::Function> cons = Nan::New<v8::Function>(constructor);
+
+  const int argc = 1;
+  v8::Local<v8::Value> argv[argc] = { Nan::New(obj->value_ * multiple) };
+
+  info.GetReturnValue().Set(cons->NewInstance(argc, argv));
+}

--- a/6_object_wrap/nan_cmake-js/myobject.cpp
+++ b/6_object_wrap/nan_cmake-js/myobject.cpp
@@ -1,65 +1,88 @@
+
 #include "myobject.hpp"
 
 Nan::Persistent<v8::Function> MyObject::constructor;
 
-MyObject::MyObject(double value) : value_(value) {
+MyObject::MyObject(double value)
+: value_(value)
+{
 }
 
-MyObject::~MyObject() {
+MyObject::~MyObject()
+{
 }
 
-void MyObject::Init(v8::Local<v8::Object> exports) {
-  Nan::HandleScope scope;
+NAN_METHOD(MyObject::New)
+{
+    if (info.IsConstructCall())
+    {
+        // invoked as constructor: `new MyObject(...)`
+        double value = info[0]->IsUndefined() ? 0 : info[0]->NumberValue();
+        MyObject* obj = new MyObject(value);
+        obj->Wrap(info.This());
 
-  // Prepare constructor template
-  v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
-  tpl->SetClassName(Nan::New("MyObject").ToLocalChecked());
-  tpl->InstanceTemplate()->SetInternalFieldCount(1);
+        info.GetReturnValue().Set(info.This());
+    }
+    else
+    {
+        // invoked as plain function `MyObject(...)`, turn into construct call.
+        const int argc = 1;
+        v8::Local<v8::Value> argv[argc] = { info[0] };
+        v8::Local<v8::Function> ctor = Nan::New<v8::Function>(constructor);
 
-  // Prototype
-  Nan::SetPrototypeMethod(tpl, "value", GetValue);
-  Nan::SetPrototypeMethod(tpl, "plusOne", PlusOne);
-  Nan::SetPrototypeMethod(tpl, "multiply", Multiply);
-
-  constructor.Reset(tpl->GetFunction());
-  exports->Set(Nan::New("MyObject").ToLocalChecked(), tpl->GetFunction());
+        info.GetReturnValue().Set(ctor->NewInstance(argc, argv));
+    }
 }
 
-void MyObject::New(const Nan::FunctionCallbackInfo<v8::Value>& info) {
-  if (info.IsConstructCall()) {
-    // Invoked as constructor: `new MyObject(...)`
-    double value = info[0]->IsUndefined() ? 0 : info[0]->NumberValue();
-    MyObject* obj = new MyObject(value);
-    obj->Wrap(info.This());
-    info.GetReturnValue().Set(info.This());
-  } else {
-    // Invoked as plain function `MyObject(...)`, turn into construct call.
+NAN_METHOD(MyObject::getValue)
+{
+    MyObject* obj = ObjectWrap::Unwrap<MyObject>(info.Holder());
+
+    info.GetReturnValue().Set(Nan::New(obj->value_));
+}
+
+NAN_METHOD(MyObject::plusOne)
+{
+    MyObject* obj = Nan::ObjectWrap::Unwrap<MyObject>(info.Holder());
+
+    obj->value_ += 1;
+
+    info.GetReturnValue().Set(Nan::New(obj->value_));
+}
+
+NAN_METHOD(MyObject::multiply)
+{
+    MyObject* obj = ObjectWrap::Unwrap<MyObject>(info.Holder());
+
+    // compute the result of the multiplication
+    double multiple = info[0]->IsUndefined() ? 1 : info[0]->NumberValue();
+    double result   = obj->value_ * multiple;
+
+    // use the result to create the new object
     const int argc = 1;
-    v8::Local<v8::Value> argv[argc] = { info[0] };
-    v8::Local<v8::Function> cons = Nan::New<v8::Function>(constructor);
-    info.GetReturnValue().Set(cons->NewInstance(argc, argv));
-  }
+    v8::Local<v8::Value> argv[argc] = { Nan::New(result) };
+    v8::Local<v8::Function> ctor = Nan::New<v8::Function>(constructor);
+
+    info.GetReturnValue().Set(ctor->NewInstance(argc, argv));
 }
 
-void MyObject::GetValue(const Nan::FunctionCallbackInfo<v8::Value>& info) {
-  MyObject* obj = ObjectWrap::Unwrap<MyObject>(info.Holder());
-  info.GetReturnValue().Set(Nan::New(obj->value_));
-}
+NAN_MODULE_INIT(MyObject::init)
+{
+    Nan::HandleScope scope;
 
-void MyObject::PlusOne(const Nan::FunctionCallbackInfo<v8::Value>& info) {
-  MyObject* obj = ObjectWrap::Unwrap<MyObject>(info.Holder());
-  obj->value_ += 1;
-  info.GetReturnValue().Set(Nan::New(obj->value_));
-}
+    // prepare constructor template
+    v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
+    tpl->SetClassName(Nan::New("MyObject").ToLocalChecked());
+    tpl->InstanceTemplate()->SetInternalFieldCount(1);  // 1 attribute: this->value_
 
-void MyObject::Multiply(const Nan::FunctionCallbackInfo<v8::Value>& info) {
-  MyObject* obj = ObjectWrap::Unwrap<MyObject>(info.Holder());
-  double multiple = info[0]->IsUndefined() ? 1 : info[0]->NumberValue();
+    // prototype
+    Nan::SetPrototypeMethod(tpl, "getValue", getValue);
+    Nan::SetPrototypeMethod(tpl, "plusOne", plusOne);
+    Nan::SetPrototypeMethod(tpl, "multiply", multiply);
 
-  v8::Local<v8::Function> cons = Nan::New<v8::Function>(constructor);
+    constructor.Reset(tpl->GetFunction());
 
-  const int argc = 1;
-  v8::Local<v8::Value> argv[argc] = { Nan::New(obj->value_ * multiple) };
-
-  info.GetReturnValue().Set(cons->NewInstance(argc, argv));
+    Nan::Set(target,
+             Nan::New("MyObject").ToLocalChecked(),
+             Nan::GetFunction(tpl).ToLocalChecked());
 }

--- a/6_object_wrap/nan_cmake-js/myobject.hpp
+++ b/6_object_wrap/nan_cmake-js/myobject.hpp
@@ -1,0 +1,22 @@
+#ifndef MYOBJECT_H
+#define MYOBJECT_H
+
+#include <nan.h>
+
+class MyObject : public Nan::ObjectWrap {
+ public:
+  static void Init(v8::Local<v8::Object> exports);
+
+ private:
+  explicit MyObject(double value = 0);
+  ~MyObject();
+
+  static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static void GetValue(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static void PlusOne(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static void Multiply(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static Nan::Persistent<v8::Function> constructor;
+  double value_;
+};
+
+#endif

--- a/6_object_wrap/nan_cmake-js/myobject.hpp
+++ b/6_object_wrap/nan_cmake-js/myobject.hpp
@@ -1,22 +1,25 @@
-#ifndef MYOBJECT_H
-#define MYOBJECT_H
+
+#pragma once
 
 #include <nan.h>
 
-class MyObject : public Nan::ObjectWrap {
- public:
-  static void Init(v8::Local<v8::Object> exports);
+class MyObject : public Nan::ObjectWrap
+{
+private:
 
- private:
-  explicit MyObject(double value = 0);
-  ~MyObject();
+    static Nan::Persistent<v8::Function> constructor;
+    double value_;
 
-  static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
-  static void GetValue(const Nan::FunctionCallbackInfo<v8::Value>& info);
-  static void PlusOne(const Nan::FunctionCallbackInfo<v8::Value>& info);
-  static void Multiply(const Nan::FunctionCallbackInfo<v8::Value>& info);
-  static Nan::Persistent<v8::Function> constructor;
-  double value_;
+    explicit MyObject(double value = 0);
+    ~MyObject();
+
+    static NAN_METHOD(New);
+
+    static NAN_METHOD(getValue);
+    static NAN_METHOD(plusOne);
+    static NAN_METHOD(multiply);  ///< @return a new object whose `value_` is `this->value_ * number`
+
+public:
+
+    static NAN_MODULE_INIT(init);
 };
-
-#endif

--- a/6_object_wrap/nan_cmake-js/package.json
+++ b/6_object_wrap/nan_cmake-js/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "object_wrap",
+  "version": "0.0.0",
+  "description": "Node.js Addons Example #6",
+  "private": true,
+  "main": "test.js",
+  "scripts": {
+    "build": "cmake-js build",
+    "rebuild": "cmake-js rebuild",
+    "test": "node test.js"
+  },
+  "dependencies": {
+    "bindings": "^1.2.1"
+  },
+  "devDependencies": {
+    "cmake-js": "^3.1.2",
+    "nan": "^2.2.1"
+  }
+}

--- a/6_object_wrap/nan_cmake-js/test.js
+++ b/6_object_wrap/nan_cmake-js/test.js
@@ -1,0 +1,13 @@
+var addon = require('bindings')('addon');
+
+var obj = new addon.MyObject(10);
+console.log( obj.plusOne() ); // 11
+console.log( obj.plusOne() ); // 12
+console.log( obj.plusOne() ); // 13
+
+console.log( obj.multiply().value() ); // 13
+console.log( obj.multiply(10).value() ); // 130
+
+var newobj = obj.multiply(-1);
+console.log( newobj.value() ); // -13
+console.log( obj === newobj ); // false

--- a/6_object_wrap/nan_cmake-js/test.js
+++ b/6_object_wrap/nan_cmake-js/test.js
@@ -1,13 +1,16 @@
+
 var addon = require('bindings')('addon');
 
 var obj = new addon.MyObject(10);
-console.log( obj.plusOne() ); // 11
-console.log( obj.plusOne() ); // 12
-console.log( obj.plusOne() ); // 13
 
-console.log( obj.multiply().value() ); // 13
-console.log( obj.multiply(10).value() ); // 130
+console.log( obj.plusOne() );  // 11
+console.log( obj.plusOne() );  // 12
+console.log( obj.plusOne() );  // 13
+
+console.log( obj.multiply().getValue() );    // 13
+console.log( obj.multiply(10).getValue() );  // 130
 
 var newobj = obj.multiply(-1);
-console.log( newobj.value() ); // -13
-console.log( obj === newobj ); // false
+
+console.log( newobj.getValue() );  // -13
+console.log( obj === newobj );     // false

--- a/7_factory_wrap/nan_cmake-js/CMakeLists.txt
+++ b/7_factory_wrap/nan_cmake-js/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(addon)
+
+set(SOURCE_FILES addon.cpp
+                 myobject.cpp
+                 myobject.hpp)
+
+add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
+set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "" SUFFIX ".node")
+target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_JS_INC})
+target_link_libraries(${PROJECT_NAME} ${CMAKE_JS_LIB})

--- a/7_factory_wrap/nan_cmake-js/addon.cpp
+++ b/7_factory_wrap/nan_cmake-js/addon.cpp
@@ -1,0 +1,17 @@
+#include <nan.h>
+#include "myobject.hpp"
+
+void CreateObject(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  info.GetReturnValue().Set(MyObject::NewInstance(info[0]));
+}
+
+void InitAll(v8::Local<v8::Object> exports, v8::Local<v8::Object> module) {
+  Nan::HandleScope scope;
+
+  MyObject::Init();
+
+  module->Set(Nan::New("exports").ToLocalChecked(),
+      Nan::New<v8::FunctionTemplate>(CreateObject)->GetFunction());
+}
+
+NODE_MODULE(addon, InitAll)

--- a/7_factory_wrap/nan_cmake-js/addon.cpp
+++ b/7_factory_wrap/nan_cmake-js/addon.cpp
@@ -1,17 +1,35 @@
+
 #include <nan.h>
+
 #include "myobject.hpp"
 
-void CreateObject(const Nan::FunctionCallbackInfo<v8::Value>& info) {
-  info.GetReturnValue().Set(MyObject::NewInstance(info[0]));
+NAN_METHOD(createObject)
+{
+    if (info.Length() != 1)
+    {
+        Nan::ThrowTypeError("Wrong number of arguments");
+        return;
+    }
+    if (!info[0]->IsNumber())
+    {
+        Nan::ThrowTypeError("Wrong argument type");
+        return;
+    }
+
+    info.GetReturnValue().Set(MyObject::NewInstance(info[0]));
 }
 
-void InitAll(v8::Local<v8::Object> exports, v8::Local<v8::Object> module) {
-  Nan::HandleScope scope;
+// module initialization
 
-  MyObject::Init();
+NAN_MODULE_INIT(init)
+{
+    Nan::HandleScope scope;
 
-  module->Set(Nan::New("exports").ToLocalChecked(),
-      Nan::New<v8::FunctionTemplate>(CreateObject)->GetFunction());
+    MyObject::init(target);
+
+    Nan::Set(target,
+             Nan::New("createObject").ToLocalChecked(),
+             Nan::GetFunction(Nan::New<v8::FunctionTemplate>(createObject)).ToLocalChecked());
 }
 
-NODE_MODULE(addon, InitAll)
+NODE_MODULE(addon, init)

--- a/7_factory_wrap/nan_cmake-js/myobject.cpp
+++ b/7_factory_wrap/nan_cmake-js/myobject.cpp
@@ -1,0 +1,50 @@
+#include <nan.h>
+#include "myobject.hpp"
+
+using namespace v8;
+
+MyObject::MyObject() {};
+MyObject::~MyObject() {};
+
+Nan::Persistent<v8::Function> MyObject::constructor;
+
+void MyObject::Init() {
+  Nan::HandleScope scope;
+
+  // Prepare constructor template
+  v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
+  tpl->SetClassName(Nan::New("MyObject").ToLocalChecked());
+  tpl->InstanceTemplate()->SetInternalFieldCount(1);
+  // Prototype
+  tpl->PrototypeTemplate()->Set(Nan::New("plusOne").ToLocalChecked(),
+      Nan::New<v8::FunctionTemplate>(PlusOne)->GetFunction());
+
+  constructor.Reset(tpl->GetFunction());
+}
+
+void MyObject::New(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  MyObject* obj = new MyObject();
+  obj->counter_ = info[0]->IsUndefined() ? 0 : info[0]->NumberValue();
+  obj->Wrap(info.This());
+
+  info.GetReturnValue().Set(info.This());
+}
+
+
+v8::Local<v8::Object> MyObject::NewInstance(v8::Local<v8::Value> arg) {
+  Nan::EscapableHandleScope scope;
+
+  const unsigned argc = 1;
+  v8::Local<v8::Value> argv[argc] = { arg };
+  v8::Local<v8::Function> cons = Nan::New<v8::Function>(constructor);
+  v8::Local<v8::Object> instance = cons->NewInstance(argc, argv);
+
+  return scope.Escape(instance);
+}
+
+void MyObject::PlusOne(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  MyObject* obj = ObjectWrap::Unwrap<MyObject>(info.This());
+  obj->counter_ += 1;
+
+  info.GetReturnValue().Set(Nan::New(obj->counter_));
+}

--- a/7_factory_wrap/nan_cmake-js/myobject.hpp
+++ b/7_factory_wrap/nan_cmake-js/myobject.hpp
@@ -1,0 +1,21 @@
+#ifndef MYOBJECT_H
+#define MYOBJECT_H
+
+#include <nan.h>
+
+class MyObject : public Nan::ObjectWrap {
+ public:
+  static void Init();
+  static v8::Local<v8::Object> NewInstance(v8::Local<v8::Value> arg);
+
+ private:
+  MyObject();
+  ~MyObject();
+
+  static Nan::Persistent<v8::Function> constructor;
+  static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static void PlusOne(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  double counter_;
+};
+
+#endif

--- a/7_factory_wrap/nan_cmake-js/myobject.hpp
+++ b/7_factory_wrap/nan_cmake-js/myobject.hpp
@@ -1,21 +1,23 @@
-#ifndef MYOBJECT_H
-#define MYOBJECT_H
+
+#pragma once
 
 #include <nan.h>
 
-class MyObject : public Nan::ObjectWrap {
+class MyObject : public Nan::ObjectWrap
+{
+private:
+
+    static Nan::Persistent<v8::Function> constructor;
+    double counter_;
+
+    MyObject();
+    ~MyObject();
+
+    static NAN_METHOD(New);
+    static NAN_METHOD(plusOne);
+
  public:
-  static void Init();
-  static v8::Local<v8::Object> NewInstance(v8::Local<v8::Value> arg);
 
- private:
-  MyObject();
-  ~MyObject();
-
-  static Nan::Persistent<v8::Function> constructor;
-  static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
-  static void PlusOne(const Nan::FunctionCallbackInfo<v8::Value>& info);
-  double counter_;
+    static v8::Local<v8::Object> NewInstance(v8::Local<v8::Value> arg);
+    static NAN_MODULE_INIT(init);
 };
-
-#endif

--- a/7_factory_wrap/nan_cmake-js/package.json
+++ b/7_factory_wrap/nan_cmake-js/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "factory_wrap",
+  "version": "0.0.0",
+  "description": "Node.js Addons Example #7",
+  "private": true,
+  "main": "test.js",
+  "scripts": {
+    "build": "cmake-js build",
+    "rebuild": "cmake-js rebuild",
+    "test": "node test.js"
+  },
+  "dependencies": {
+    "bindings": "^1.2.1"
+  },
+  "devDependencies": {
+    "cmake-js": "^3.1.2",
+    "nan": "^2.2.1"
+  }
+}

--- a/7_factory_wrap/nan_cmake-js/test.js
+++ b/7_factory_wrap/nan_cmake-js/test.js
@@ -1,0 +1,11 @@
+var createObject = require('bindings')('addon');
+
+var obj = createObject(10);
+console.log( obj.plusOne() ); // 11
+console.log( obj.plusOne() ); // 12
+console.log( obj.plusOne() ); // 13
+
+var obj2 = createObject(20);
+console.log( obj2.plusOne() ); // 21
+console.log( obj2.plusOne() ); // 22
+console.log( obj2.plusOne() ); // 23

--- a/7_factory_wrap/nan_cmake-js/test.js
+++ b/7_factory_wrap/nan_cmake-js/test.js
@@ -1,11 +1,14 @@
-var createObject = require('bindings')('addon');
 
-var obj = createObject(10);
-console.log( obj.plusOne() ); // 11
-console.log( obj.plusOne() ); // 12
-console.log( obj.plusOne() ); // 13
+var addon = require('bindings')('addon');
 
-var obj2 = createObject(20);
-console.log( obj2.plusOne() ); // 21
-console.log( obj2.plusOne() ); // 22
-console.log( obj2.plusOne() ); // 23
+var obj = addon.createObject(10);
+
+console.log( obj.plusOne() );  // 11
+console.log( obj.plusOne() );  // 12
+console.log( obj.plusOne() );  // 13
+
+var obj2 = addon.createObject(20);
+
+console.log( obj2.plusOne() );  // 21
+console.log( obj2.plusOne() );  // 22
+console.log( obj2.plusOne() );  // 23

--- a/8_passing_wrapped/nan_cmake-js/CMakeLists.txt
+++ b/8_passing_wrapped/nan_cmake-js/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(addon)
+
+set(SOURCE_FILES addon.cpp
+                 myobject.cpp
+                 myobject.hpp)
+
+add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
+set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "" SUFFIX ".node")
+target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_JS_INC})
+target_link_libraries(${PROJECT_NAME} ${CMAKE_JS_LIB})

--- a/8_passing_wrapped/nan_cmake-js/addon.cpp
+++ b/8_passing_wrapped/nan_cmake-js/addon.cpp
@@ -1,0 +1,27 @@
+#include <nan.h>
+#include "myobject.hpp"
+
+using namespace v8;
+
+void CreateObject(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  info.GetReturnValue().Set(MyObject::NewInstance(info[0]));
+}
+
+void Add(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  MyObject* obj1 = Nan::ObjectWrap::Unwrap<MyObject>(info[0]->ToObject());
+  MyObject* obj2 = Nan::ObjectWrap::Unwrap<MyObject>(info[1]->ToObject());
+  double sum = obj1->Val() + obj2->Val();
+  info.GetReturnValue().Set(Nan::New(sum));
+}
+
+void InitAll(v8::Local<v8::Object> exports) {
+  MyObject::Init();
+
+  exports->Set(Nan::New("createObject").ToLocalChecked(),
+      Nan::New<v8::FunctionTemplate>(CreateObject)->GetFunction());
+
+  exports->Set(Nan::New("add").ToLocalChecked(),
+      Nan::New<v8::FunctionTemplate>(Add)->GetFunction());
+}
+
+NODE_MODULE(addon, InitAll)

--- a/8_passing_wrapped/nan_cmake-js/addon.cpp
+++ b/8_passing_wrapped/nan_cmake-js/addon.cpp
@@ -1,27 +1,38 @@
+
 #include <nan.h>
+
 #include "myobject.hpp"
 
-using namespace v8;
+NAN_METHOD(createObject);  ///< object factory
+NAN_METHOD(add);           ///< object consumer
 
-void CreateObject(const Nan::FunctionCallbackInfo<v8::Value>& info) {
-  info.GetReturnValue().Set(MyObject::NewInstance(info[0]));
+NAN_METHOD(createObject)
+{
+    info.GetReturnValue().Set(MyObject::NewInstance(info[0]));
 }
 
-void Add(const Nan::FunctionCallbackInfo<v8::Value>& info) {
-  MyObject* obj1 = Nan::ObjectWrap::Unwrap<MyObject>(info[0]->ToObject());
-  MyObject* obj2 = Nan::ObjectWrap::Unwrap<MyObject>(info[1]->ToObject());
-  double sum = obj1->Val() + obj2->Val();
-  info.GetReturnValue().Set(Nan::New(sum));
+NAN_METHOD(add)
+{
+    MyObject* obj1 = Nan::ObjectWrap::Unwrap<MyObject>(info[0]->ToObject());
+    MyObject* obj2 = Nan::ObjectWrap::Unwrap<MyObject>(info[1]->ToObject());
+
+    double sum = obj1->val() + obj2->val();
+
+    info.GetReturnValue().Set(Nan::New(sum));
 }
 
-void InitAll(v8::Local<v8::Object> exports) {
-  MyObject::Init();
+// module initialization
 
-  exports->Set(Nan::New("createObject").ToLocalChecked(),
-      Nan::New<v8::FunctionTemplate>(CreateObject)->GetFunction());
+NAN_MODULE_INIT(init)
+{
+    MyObject::init(target);
 
-  exports->Set(Nan::New("add").ToLocalChecked(),
-      Nan::New<v8::FunctionTemplate>(Add)->GetFunction());
+    Nan::Set(target,
+             Nan::New("createObject").ToLocalChecked(),
+             Nan::GetFunction(Nan::New<v8::FunctionTemplate>(createObject)).ToLocalChecked());
+    Nan::Set(target,
+             Nan::New("add").ToLocalChecked(),
+             Nan::GetFunction(Nan::New<v8::FunctionTemplate>(add)).ToLocalChecked());
 }
 
-NODE_MODULE(addon, InitAll)
+NODE_MODULE(addon, init)

--- a/8_passing_wrapped/nan_cmake-js/myobject.cpp
+++ b/8_passing_wrapped/nan_cmake-js/myobject.cpp
@@ -1,37 +1,51 @@
-#include <node.h>
-#include "myobject.hpp"
 
-MyObject::MyObject() {};
-MyObject::~MyObject() {};
+#include "myobject.hpp"
 
 Nan::Persistent<v8::Function> MyObject::constructor;
 
-void MyObject::Init() {
-  Nan::HandleScope scope;
-
-  // Prepare constructor template
-  v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
-  tpl->SetClassName(Nan::New("MyObject").ToLocalChecked());
-  tpl->InstanceTemplate()->SetInternalFieldCount(1);
-
-  constructor.Reset(tpl->GetFunction());
+MyObject::MyObject()
+: val_(0)
+{
 }
 
-void MyObject::New(const Nan::FunctionCallbackInfo<v8::Value>& info) {
-  MyObject* obj = new MyObject();
-  obj->val_ = info[0]->IsUndefined() ? 0 : info[0]->NumberValue();
-  obj->Wrap(info.This());
-
-  info.GetReturnValue().Set(info.This());
+MyObject::~MyObject()
+{
 }
 
-v8::Local<v8::Object> MyObject::NewInstance(v8::Local<v8::Value> arg) {
-  Nan::EscapableHandleScope scope;
+NAN_METHOD(MyObject::New)
+{
+    MyObject* obj = new MyObject();
+    obj->val_ = info[0]->IsUndefined() ? 0 : info[0]->NumberValue();
+    obj->Wrap(info.This());
 
-  const unsigned argc = 1;
-  v8::Local<v8::Value> argv[argc] = { arg };
-  v8::Local<v8::Function> cons = Nan::New<v8::Function>(constructor);
-  v8::Local<v8::Object> instance = cons->NewInstance(argc, argv);
+    info.GetReturnValue().Set(info.This());
+}
 
-  return scope.Escape(instance);
+double MyObject::val() const
+{
+    return val_;
+}
+
+v8::Local<v8::Object> MyObject::NewInstance(v8::Local<v8::Value> arg)
+{
+    Nan::EscapableHandleScope scope;
+
+    const unsigned argc = 1;
+    v8::Local<v8::Value> argv[argc] = { arg };
+    v8::Local<v8::Function> ctor = Nan::New<v8::Function>(constructor);
+    v8::Local<v8::Object> instance = ctor->NewInstance(argc, argv);
+
+    return scope.Escape(instance);
+}
+
+NAN_MODULE_INIT(MyObject::init)
+{
+    Nan::HandleScope scope;
+
+    // prepare constructor template
+    v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
+    tpl->SetClassName(Nan::New("MyObject").ToLocalChecked());
+    tpl->InstanceTemplate()->SetInternalFieldCount(1);  // 1 attribute: this->val_
+
+    constructor.Reset(tpl->GetFunction());
 }

--- a/8_passing_wrapped/nan_cmake-js/myobject.cpp
+++ b/8_passing_wrapped/nan_cmake-js/myobject.cpp
@@ -1,0 +1,37 @@
+#include <node.h>
+#include "myobject.hpp"
+
+MyObject::MyObject() {};
+MyObject::~MyObject() {};
+
+Nan::Persistent<v8::Function> MyObject::constructor;
+
+void MyObject::Init() {
+  Nan::HandleScope scope;
+
+  // Prepare constructor template
+  v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
+  tpl->SetClassName(Nan::New("MyObject").ToLocalChecked());
+  tpl->InstanceTemplate()->SetInternalFieldCount(1);
+
+  constructor.Reset(tpl->GetFunction());
+}
+
+void MyObject::New(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  MyObject* obj = new MyObject();
+  obj->val_ = info[0]->IsUndefined() ? 0 : info[0]->NumberValue();
+  obj->Wrap(info.This());
+
+  info.GetReturnValue().Set(info.This());
+}
+
+v8::Local<v8::Object> MyObject::NewInstance(v8::Local<v8::Value> arg) {
+  Nan::EscapableHandleScope scope;
+
+  const unsigned argc = 1;
+  v8::Local<v8::Value> argv[argc] = { arg };
+  v8::Local<v8::Function> cons = Nan::New<v8::Function>(constructor);
+  v8::Local<v8::Object> instance = cons->NewInstance(argc, argv);
+
+  return scope.Escape(instance);
+}

--- a/8_passing_wrapped/nan_cmake-js/myobject.hpp
+++ b/8_passing_wrapped/nan_cmake-js/myobject.hpp
@@ -1,0 +1,21 @@
+#ifndef MYOBJECT_H
+#define MYOBJECT_H
+
+#include <nan.h>
+
+class MyObject : public Nan::ObjectWrap {
+ public:
+  static void Init();
+  static v8::Local<v8::Object> NewInstance(v8::Local<v8::Value> arg);
+  double Val() const { return val_; }
+
+ private:
+  MyObject();
+  ~MyObject();
+
+  static Nan::Persistent<v8::Function> constructor;
+  static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  double val_;
+};
+
+#endif

--- a/8_passing_wrapped/nan_cmake-js/myobject.hpp
+++ b/8_passing_wrapped/nan_cmake-js/myobject.hpp
@@ -1,21 +1,24 @@
-#ifndef MYOBJECT_H
-#define MYOBJECT_H
+
+#pragma once
 
 #include <nan.h>
 
-class MyObject : public Nan::ObjectWrap {
- public:
-  static void Init();
-  static v8::Local<v8::Object> NewInstance(v8::Local<v8::Value> arg);
-  double Val() const { return val_; }
+class MyObject : public Nan::ObjectWrap
+{
+private:
 
- private:
-  MyObject();
-  ~MyObject();
+    static Nan::Persistent<v8::Function> constructor;
+    double val_;
 
-  static Nan::Persistent<v8::Function> constructor;
-  static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
-  double val_;
+    MyObject();
+    ~MyObject();
+
+    static NAN_METHOD(New);
+
+public:
+
+    double val() const;
+
+    static v8::Local<v8::Object> NewInstance(v8::Local<v8::Value> arg);
+    static NAN_MODULE_INIT(init);
 };
-
-#endif

--- a/8_passing_wrapped/nan_cmake-js/package.json
+++ b/8_passing_wrapped/nan_cmake-js/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "passing_wrapped",
+  "version": "0.0.0",
+  "description": "Node.js Addons Example #8",
+  "private": true,
+  "main": "test.js",
+  "scripts": {
+    "build": "cmake-js build",
+    "rebuild": "cmake-js rebuild",
+    "test": "node test.js"
+  },
+  "dependencies": {
+    "bindings": "^1.2.1"
+  },
+  "devDependencies": {
+    "cmake-js": "^3.1.2",
+    "nan": "^2.2.1"
+  }
+}

--- a/8_passing_wrapped/nan_cmake-js/test.js
+++ b/8_passing_wrapped/nan_cmake-js/test.js
@@ -1,0 +1,7 @@
+var addon = require('bindings')('addon');
+
+var obj1 = addon.createObject(10);
+var obj2 = addon.createObject(20);
+var result = addon.add(obj1, obj2);
+
+console.log(result); // 30

--- a/8_passing_wrapped/nan_cmake-js/test.js
+++ b/8_passing_wrapped/nan_cmake-js/test.js
@@ -1,7 +1,9 @@
+
 var addon = require('bindings')('addon');
 
-var obj1 = addon.createObject(10);
-var obj2 = addon.createObject(20);
+var obj1   = addon.createObject(10);
+var obj2   = addon.createObject(20);
+
 var result = addon.add(obj1, obj2);
 
-console.log(result); // 30
+console.log(result);  // 30


### PR DESCRIPTION
Hi,

I'm currently learning how to interface C++ code with Node.js (and later with Electron) and I found the examples very helpful :)

Since NAN and CMake made my task easier, I would like to suggest the following:
- Copy `*/nan` examples to `*/nan_cmake-js`
- Use [CMake.js](https://www.npmjs.com/package/cmake-js) instead of `gyp`
- Use NAN's shorthands (e.g. `NAN_METHOD()`) over full signatures
- Minor updates to the JavaScript code

Thanks