### PR TITLE
examples: fix abort in nan version of 7_object_wrap

### DIFF
--- a/7_factory_wrap/nan/myobject.cc
+++ b/7_factory_wrap/nan/myobject.cc
@@ -17,7 +17,7 @@ void MyObject::Init() {
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
   // Prototype
   tpl->PrototypeTemplate()->Set(Nan::New("plusOne").ToLocalChecked(),
-      Nan::New<v8::FunctionTemplate>(PlusOne)->GetFunction());
+      Nan::New<v8::FunctionTemplate>(PlusOne));
 
   constructor.Reset(tpl->GetFunction());
 }


### PR DESCRIPTION
When creating a prototype method, the `FunctionTemplate` must be
attached to the `PrototypeTemplate`, not the resulting `Function`.

Fixes: https://github.com/nodejs/node-addon-examples/issues/64