### PR TITLE
lock cmake-js to 5 for Node.js 8 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
 cache:
   npm
 before_install:
-  - npm install -g cmake-js
+  - npm install -g cmake-js@5.3.2
 before_script:
   - npx envinfo
 script:


### PR DESCRIPTION
Related: https://github.com/nodejs/node-addon-examples/pull/116#issuecomment-539298607