### PR TITLE
using AsyncResource::runInAsyncScope invoke callback in the nan of 3_callbacks file

### DIFF
--- a/3_callbacks/nan/addon.cc
+++ b/3_callbacks/nan/addon.cc
@@ -4,7 +4,7 @@ void RunCallback(const Nan::FunctionCallbackInfo<v8::Value>& info) {
   v8::Local<v8::Function> cb = info[0].As<v8::Function>();
   const unsigned argc = 1;
   v8::Local<v8::Value> argv[argc] = {Nan::New("hello world").ToLocalChecked()};
-  Nan::AsyncResource resource(Nan::New<v8::String>().ToLocalChecked());
+  Nan::AsyncResource resource("nan:makeCallback");
   resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), cb, argc, argv);
 }
 

--- a/3_callbacks/nan/addon.cc
+++ b/3_callbacks/nan/addon.cc
@@ -4,7 +4,8 @@ void RunCallback(const Nan::FunctionCallbackInfo<v8::Value>& info) {
   v8::Local<v8::Function> cb = info[0].As<v8::Function>();
   const unsigned argc = 1;
   v8::Local<v8::Value> argv[argc] = {Nan::New("hello world").ToLocalChecked()};
-  Nan::MakeCallback(Nan::GetCurrentContext()->Global(), cb, argc, argv);
+  Nan::AsyncResource resource(Nan::New<v8::String>().ToLocalChecked());
+  resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), cb, argc, argv);
 }
 
 void Init(v8::Local<v8::Object> exports, v8::Local<v8::Object> module) {


### PR DESCRIPTION
Deprecated wrappers around the legacy `node::MakeCallback()` APIs, using the `AsyncResource::runInAsyncScope`