### PR TITLE
make node-addon-api examples context-sensistive

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 13.x]
+        node-version: [10.x, 12.x, 13.x, 14.x]
         operating-system: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 13.x, 14.x]
+        node-version: [10.21.0, 12.18.0, 13.x, 14.x]
         operating-system: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
-  - "8"
   - "10"
   - "12"
   - "13"
+  - "14"
 cache:
   npm
 before_install:

--- a/6_object_wrap/node-addon-api/myobject.cc
+++ b/6_object_wrap/node-addon-api/myobject.cc
@@ -1,7 +1,5 @@
 #include "myobject.h"
 
-Napi::FunctionReference MyObject::constructor;
-
 Napi::Object MyObject::Init(Napi::Env env, Napi::Object exports) {
   Napi::HandleScope scope(env);
 
@@ -12,8 +10,9 @@ Napi::Object MyObject::Init(Napi::Env env, Napi::Object exports) {
                    InstanceMethod("value", &MyObject::GetValue),
                    InstanceMethod("multiply", &MyObject::Multiply)});
 
-  constructor = Napi::Persistent(func);
-  constructor.SuppressDestruct();
+  Napi::FunctionReference* constructor = new Napi::FunctionReference();
+  *constructor = Napi::Persistent(func);
+  env.SetInstanceData(constructor);
 
   exports.Set("MyObject", func);
   return exports;
@@ -55,7 +54,7 @@ Napi::Value MyObject::Multiply(const Napi::CallbackInfo& info) {
     multiple = info[0].As<Napi::Number>();
   }
 
-  Napi::Object obj = constructor.New(
+  Napi::Object obj = info.Env().GetInstanceData<Napi::FunctionReference>()->New(
       {Napi::Number::New(info.Env(), this->value_ * multiple.DoubleValue())});
 
   return obj;

--- a/6_object_wrap/node-addon-api/myobject.h
+++ b/6_object_wrap/node-addon-api/myobject.h
@@ -9,8 +9,6 @@ class MyObject : public Napi::ObjectWrap<MyObject> {
   MyObject(const Napi::CallbackInfo& info);
 
  private:
-  static Napi::FunctionReference constructor;
-
   Napi::Value GetValue(const Napi::CallbackInfo& info);
   Napi::Value PlusOne(const Napi::CallbackInfo& info);
   Napi::Value Multiply(const Napi::CallbackInfo& info);

--- a/6_object_wrap/node-addon-api/package.json
+++ b/6_object_wrap/node-addon-api/package.json
@@ -5,6 +5,9 @@
   "main": "addon.js",
   "private": true,
   "gypfile": true,
+  "engines": {
+    "node": "~10 >=10.20 || >=12.17"
+  },
   "dependencies": {
     "bindings": "~1.2.1",
     "node-addon-api": "^3.0.0"

--- a/6_object_wrap/node-addon-api/package.json
+++ b/6_object_wrap/node-addon-api/package.json
@@ -7,6 +7,6 @@
   "gypfile": true,
   "dependencies": {
     "bindings": "~1.2.1",
-    "node-addon-api": "^1.0.0"
+    "node-addon-api": "^3.0.0"
   }
 }

--- a/7_factory_wrap/node-addon-api/myobject.cc
+++ b/7_factory_wrap/node-addon-api/myobject.cc
@@ -4,16 +4,15 @@
 
 using namespace Napi;
 
-Napi::FunctionReference MyObject::constructor;
-
 Napi::Object MyObject::Init(Napi::Env env, Napi::Object exports) {
   Napi::HandleScope scope(env);
 
   Napi::Function func = DefineClass(
       env, "MyObject", {InstanceMethod("plusOne", &MyObject::PlusOne)});
 
-  constructor = Napi::Persistent(func);
-  constructor.SuppressDestruct();
+  Napi::FunctionReference* constructor = new Napi::FunctionReference();
+  *constructor = Napi::Persistent(func);
+  env.SetInstanceData(constructor);
 
   exports.Set("MyObject", func);
   return exports;
@@ -29,7 +28,7 @@ MyObject::MyObject(const Napi::CallbackInfo& info)
 
 Napi::Object MyObject::NewInstance(Napi::Env env, Napi::Value arg) {
   Napi::EscapableHandleScope scope(env);
-  Napi::Object obj = constructor.New({arg});
+  Napi::Object obj = env.GetInstanceData<Napi::FunctionReference>()->New({arg});
   return scope.Escape(napi_value(obj)).ToObject();
 }
 

--- a/7_factory_wrap/node-addon-api/myobject.h
+++ b/7_factory_wrap/node-addon-api/myobject.h
@@ -10,7 +10,6 @@ class MyObject : public Napi::ObjectWrap<MyObject> {
   MyObject(const Napi::CallbackInfo& info);
 
  private:
-  static Napi::FunctionReference constructor;
   Napi::Value PlusOne(const Napi::CallbackInfo& info);
   double counter_;
 };

--- a/7_factory_wrap/node-addon-api/package.json
+++ b/7_factory_wrap/node-addon-api/package.json
@@ -5,6 +5,9 @@
   "main": "addon.js",
   "private": true,
   "gypfile": true,
+  "engines": {
+    "node": "~10 >=10.20 || >=12.17"
+  },
   "dependencies": {
     "bindings": "~1.2.1",
     "node-addon-api": "^3.0.0"

--- a/7_factory_wrap/node-addon-api/package.json
+++ b/7_factory_wrap/node-addon-api/package.json
@@ -7,6 +7,6 @@
   "gypfile": true,
   "dependencies": {
     "bindings": "~1.2.1",
-    "node-addon-api": "^1.0.0"
+    "node-addon-api": "^3.0.0"
   }
 }

--- a/8_passing_wrapped/node-addon-api/addon.cc
+++ b/8_passing_wrapped/node-addon-api/addon.cc
@@ -4,7 +4,7 @@
 using namespace Napi;
 
 Napi::Object CreateObject(const Napi::CallbackInfo& info) {
-  return MyObject::NewInstance(info[0]);
+  return MyObject::NewInstance(info.Env(), info[0]);
 }
 
 Napi::Number Add(const Napi::CallbackInfo& info) {

--- a/8_passing_wrapped/node-addon-api/myobject.cc
+++ b/8_passing_wrapped/node-addon-api/myobject.cc
@@ -10,20 +10,19 @@ MyObject::MyObject(const Napi::CallbackInfo& info)
   this->val_ = info[0].As<Napi::Number>().DoubleValue();
 };
 
-Napi::FunctionReference MyObject::constructor;
-
 void MyObject::Init(Napi::Env env, Napi::Object exports) {
   Napi::HandleScope scope(env);
 
   Napi::Function func = DefineClass(env, "MyObject", {});
 
-  constructor = Napi::Persistent(func);
-  constructor.SuppressDestruct();
+  Napi::FunctionReference* constructor = new Napi::FunctionReference();
+  *constructor = Napi::Persistent(func);
+  env.SetInstanceData(constructor);
 
   exports.Set("MyObject", func);
 }
 
-Napi::Object MyObject::NewInstance(Napi::Value arg) {
-  Napi::Object obj = constructor.New({arg});
+Napi::Object MyObject::NewInstance(Napi::Env env, Napi::Value arg) {
+  Napi::Object obj = env.GetInstanceData<Napi::FunctionReference>()->New({arg});
   return obj;
 }

--- a/8_passing_wrapped/node-addon-api/myobject.h
+++ b/8_passing_wrapped/node-addon-api/myobject.h
@@ -6,12 +6,11 @@
 class MyObject : public Napi::ObjectWrap<MyObject> {
  public:
   static void Init(Napi::Env env, Napi::Object exports);
-  static Napi::Object NewInstance(Napi::Value arg);
+  static Napi::Object NewInstance(Napi::Env env, Napi::Value arg);
   double Val() const { return val_; }
   MyObject(const Napi::CallbackInfo& info);
 
  private:
-  static Napi::FunctionReference constructor;
   double val_;
 };
 

--- a/8_passing_wrapped/node-addon-api/package.json
+++ b/8_passing_wrapped/node-addon-api/package.json
@@ -5,6 +5,9 @@
   "main": "addon.js",
   "private": true,
   "gypfile": true,
+  "engines": {
+    "node": "~10 >=10.20 || >=12.17"
+  },
   "dependencies": {
     "bindings": "~1.2.1",
     "node-addon-api": "^3.0.0"

--- a/8_passing_wrapped/node-addon-api/package.json
+++ b/8_passing_wrapped/node-addon-api/package.json
@@ -7,6 +7,6 @@
   "gypfile": true,
   "dependencies": {
     "bindings": "~1.2.1",
-    "node-addon-api": "^1.0.0"
+    "node-addon-api": "^3.0.0"
   }
 }


### PR DESCRIPTION
This removes global static references from the examples, so that they
might work with worker threads.