### PR TITLE
Remove unneeded Napi::HandleScope objects

### DIFF
--- a/6_object_wrap/node-addon-api/myobject.cc
+++ b/6_object_wrap/node-addon-api/myobject.cc
@@ -3,7 +3,6 @@
 Napi::FunctionReference MyObject::constructor;
 
 Napi::Object MyObject::Init(Napi::Env env, Napi::Object exports) {
-  Napi::HandleScope scope(env);
 
   Napi::Function func =
       DefineClass(env,
@@ -22,7 +21,6 @@ Napi::Object MyObject::Init(Napi::Env env, Napi::Object exports) {
 MyObject::MyObject(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<MyObject>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   int length = info.Length();
 

--- a/7_factory_wrap/node-addon-api/myobject.cc
+++ b/7_factory_wrap/node-addon-api/myobject.cc
@@ -7,7 +7,6 @@ using namespace Napi;
 Napi::FunctionReference MyObject::constructor;
 
 Napi::Object MyObject::Init(Napi::Env env, Napi::Object exports) {
-  Napi::HandleScope scope(env);
 
   Napi::Function func = DefineClass(
       env, "MyObject", {InstanceMethod("plusOne", &MyObject::PlusOne)});
@@ -21,8 +20,6 @@ Napi::Object MyObject::Init(Napi::Env env, Napi::Object exports) {
 
 MyObject::MyObject(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<MyObject>(info) {
-  Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   this->counter_ = info[0].As<Napi::Number>().DoubleValue();
 };

--- a/8_passing_wrapped/node-addon-api/myobject.cc
+++ b/8_passing_wrapped/node-addon-api/myobject.cc
@@ -4,8 +4,6 @@
 
 MyObject::MyObject(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<MyObject>(info) {
-  Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   this->val_ = info[0].As<Napi::Number>().DoubleValue();
 };
@@ -13,7 +11,6 @@ MyObject::MyObject(const Napi::CallbackInfo& info)
 Napi::FunctionReference MyObject::constructor;
 
 void MyObject::Init(Napi::Env env, Napi::Object exports) {
-  Napi::HandleScope scope(env);
 
   Napi::Function func = DefineClass(env, "MyObject", {});
 

--- a/async_pi_estimate/node-addon-api/async.cc
+++ b/async_pi_estimate/node-addon-api/async.cc
@@ -18,7 +18,6 @@ class PiWorker : public Napi::AsyncWorker {
   // this function will be run inside the main event loop
   // so it is safe to use JS engine data again
   void OnOK() {
-    Napi::HandleScope scope(Env());
     Callback().Call({Env().Undefined(), Napi::Number::New(Env(), estimate)});
   }
 

--- a/function-reference-demo/node-addon-api/src/native-addon.cc
+++ b/function-reference-demo/node-addon-api/src/native-addon.cc
@@ -4,7 +4,6 @@
 Napi::FunctionReference NativeAddon::constructor;
 
 Napi::Object NativeAddon::Init(Napi::Env env, Napi::Object exports) {
-  Napi::HandleScope scope(env);
   
   Napi::Function func = DefineClass(env, "NativeAddon", {
     InstanceMethod("tryCallByStoredReference", &NativeAddon::TryCallByStoredReference),

--- a/inherits_from_event_emitter/node-addon-api/src/native-emitter.cc
+++ b/inherits_from_event_emitter/node-addon-api/src/native-emitter.cc
@@ -7,8 +7,7 @@
 Napi::FunctionReference NativeEmitter::constructor;
 
 Napi::Object NativeEmitter::Init(Napi::Env env, Napi::Object exports) {
-  Napi::HandleScope scope(env);
-
+  
   Napi::Function func =
       DefineClass(env,
                   "NativeEmitter",


### PR DESCRIPTION
This PR removes the unneeded ` Napi::HandleScope` objects as identified in https://github.com/nodejs/node-addon-examples/issues/135 and https://github.com/nodejs/node-addon-examples/issues/142.