### PR TITLE
add link to the n-api tutorial website

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ completeness and historical context. They are not maintained.
 
 The [N-API Resource](http://nodejs.github.io/node-addon-examples/) offers an 
 excellent orientation and tips for developers just getting started with N-API 
-and node-addon-api.
+and `node-addon-api`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,17 @@ Node.js Addon Examples
 
 Implementations of examples are named either after Node.js versions (`node_0.10`,
 `node_0.12`, etc), or Node.js addon implementation APIs:
+
 - [`nan`](https://github.com/nodejs/nan): C++-based abstraction between Node and direct V8 APIs.
 - [`napi`](https://nodejs.org/api/n-api.html): C-based API guaranteeing [ABI stability](https://nodejs.org/en/docs/guides/abi-stability/) across different node versions as well as JavaScript engines.
 - [`node-addon-api`](https://github.com/nodejs/node-addon-api): header-only C++ wrapper classes which simplify the use of the C-based N-API.
 
 Implementations against unsupported versions of Node.js are provided for
-completess and historical context. They are not maintained.
+completeness and historical context. They are not maintained.
+
+The [N-API Resource](http://nodejs.github.io/node-addon-examples/) offers an 
+excellent orientation and tips for developers just getting started with N-API 
+and node-addon-api.
 
 ## Usage
 
@@ -38,3 +43,4 @@ $ node ./
 ```
 
 to see the example in action.
+


### PR DESCRIPTION
This PR adds a link to the N-API tutorial website to the repo's README file.