### PR TITLE
doc: clarify focus is on n-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,16 @@ Implementations of examples are named either after Node.js versions (`node_0.10`
 `node_0.12`, etc), or Node.js addon implementation APIs:
 
 - [`nan`](https://github.com/nodejs/nan): C++-based abstraction between Node and direct V8 APIs.
-- [`napi`](https://nodejs.org/api/n-api.html): C-based API guaranteeing [ABI stability](https://nodejs.org/en/docs/guides/abi-stability/) across different node versions as well as JavaScript engines.
+- [`N-API`](https://nodejs.org/api/n-api.html): C-based API guaranteeing [ABI stability](https://nodejs.org/en/docs/guides/abi-stability/) across different node versions as well as JavaScript engines.
 - [`node-addon-api`](https://github.com/nodejs/node-addon-api): header-only C++ wrapper classes which simplify the use of the C-based N-API.
 
 Implementations against unsupported versions of Node.js are provided for
 completeness and historical context. They are not maintained.
+
+The examples are primarily maintained for N-API and node-addon-api and as outlined in
+the Node.js [documentation](https://nodejs.org/dist/latest/docs/api/addons.html), 
+unless there is a need for direct access to functionality which
+is not exposed by N-API, use N-API. 
 
 The [N-API Resource](http://nodejs.github.io/node-addon-examples/) offers an 
 excellent orientation and tips for developers just getting started with N-API 


### PR DESCRIPTION
Clarify that examples are primarily maintained for
N-API and node-addon-api.

Signed-off-by: Michael Dawson <mdawson@devrus.com>