### PR TITLE
simplify a little Cmake config with regex

### DIFF
--- a/build_with_cmake/node-addon-api/CMakeLists.txt
+++ b/build_with_cmake/node-addon-api/CMakeLists.txt
@@ -14,8 +14,8 @@ execute_process(COMMAND node -p "require('node-addon-api').include"
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         OUTPUT_VARIABLE NODE_ADDON_API_DIR
         )
-string(REPLACE "\n" "" NODE_ADDON_API_DIR ${NODE_ADDON_API_DIR})
-string(REPLACE "\"" "" NODE_ADDON_API_DIR ${NODE_ADDON_API_DIR})
+string(REGEX REPLACE "[\r\n\"]" "" NODE_ADDON_API_DIR ${NODE_ADDON_API_DIR})
+
 target_include_directories(${PROJECT_NAME} PRIVATE ${NODE_ADDON_API_DIR})
 
 # define NPI_VERSION


### PR DESCRIPTION
Removes one line of CMakeLists.txt config file by using regex to run both replaces at one time.

