### PR TITLE
Update myobject.cc

### DIFF
--- a/8_passing_wrapped/node-addon-api/myobject.cc
+++ b/8_passing_wrapped/node-addon-api/myobject.cc
@@ -12,7 +12,8 @@ void MyObject::Init(Napi::Env env, Napi::Object exports) {
 
   Napi::FunctionReference* constructor = new Napi::FunctionReference();
   *constructor = Napi::Persistent(func);
-  env.SetInstanceData(constructor);
+  env.SetInstanceData(constructor); //NOTE: this assumes only 1 class is exported
+                                    //for multiple exported classes, need a struct or other mechanism
 
   exports.Set("MyObject", func);
 }


### PR DESCRIPTION
It would be helpful to add a reminder/note that SetInstance/GetInstance are not specific to this object class.  If the node addon exports multiple classes, the ctors can't all be stored with SetInstance/GetInstance without some kind of struct or naming convention to distinguish between them.