### PR TITLE
doc: update URL links from 'master' to 'HEAD'

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -2,7 +2,7 @@ name: Build and Deploy the Website
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   deploy-website:

--- a/website/README.md
+++ b/website/README.md
@@ -60,7 +60,7 @@ For this project, Gatsby is configured to have the ability to copy example sourc
 Here's the pattern to follow for embedding example source code:
 
 ```
-[**package.json**](https://github.com/nodejs/node-addon-examples/blob/master/object-wrap-demo/node-addon-api/package.json)
+[**package.json**](https://github.com/nodejs/node-addon-examples/blob/HEAD/object-wrap-demo/node-addon-api/package.json)
 
 `embed:object-wrap-demo/node-addon-api/package.json`
 ```

--- a/website/src/components/foundations/reset/styles/base.ts
+++ b/website/src/components/foundations/reset/styles/base.ts
@@ -81,7 +81,7 @@ const base = css`
     }
   }
 
-  /* https://github.com/reach/reach-ui/blob/master/packages/skip-nav/styles.css */
+  /* https://github.com/reach/reach-ui/blob/HEAD/packages/skip-nav/styles.css */
   [data-reach-skip-link] {
     border: 0;
     clip: rect(0 0 0 0);

--- a/website/src/components/foundations/reset/styles/reboot.ts
+++ b/website/src/components/foundations/reset/styles/reboot.ts
@@ -5,8 +5,8 @@ const reboot = css`
    * Bootstrap Reboot v4.1.2 (https://getbootstrap.com/)
    * Copyright 2011-2018 The Bootstrap Authors
    * Copyright 2011-2018 Twitter, Inc.
-   * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
-   * Forked from Normalize.css, licensed MIT (https://github.com/necolas/normalize.css/blob/master/LICENSE.md)
+   * Licensed under MIT (https://github.com/twbs/bootstrap/blob/HEAD/LICENSE)
+   * Forked from Normalize.css, licensed MIT (https://github.com/necolas/normalize.css/blob/HEAD/LICENSE.md)
    */
   *,
   *::before,

--- a/website/src/utils/types.ts
+++ b/website/src/utils/types.ts
@@ -1,13 +1,13 @@
 /**
  * Omits a property from an object.
  *
- * @borrows https://github.com/dfee/rbx/blob/master/src/types.ts#L3
+ * @borrows https://github.com/dfee/rbx/blob/HEAD/src/types.ts#L3
  */
 export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 
 /**
  * Takes two items and merges its properties. If there’s a collision, it prefers the *first* item.
  *
- * @borrows https://github.com/dfee/rbx/blob/master/src/types.ts#L3
+ * @borrows https://github.com/dfee/rbx/blob/HEAD/src/types.ts#L3
  */
 export type Prefer<P, T> = P & Omit<T, keyof P>;


### PR DESCRIPTION
Also update the GitHub Action that builds the N-API Resource website.

This PR should be merged after the default branch of this repo changed from from `master` to `main`.

See https://github.com/nodejs/abi-stable-node/issues/421.