### PR TITLE
Update CI component versions

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -6,7 +6,7 @@ jobs:
   check-clang-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: npm install
       - name: check clang-format
         run: |

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,16 +12,16 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.18.0, 14.x, 16.x]
-        operating-system: [ubuntu-latest, windows-2019, macos-latest]
+        node-version: [14.x, 16.x, 18.x]
+        operating-system: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm install -g cmake-js@5.3.2
+      - run: npm install -g cmake-js@6.3.2
       - run: npm install
       - name: Environment Information
         run: npx envinfo
@@ -32,12 +32,12 @@ jobs:
     runs-on: ubuntu-latest
     container: node
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: npm i -g n && n nightly
       - run: node -p process.versions
       - name: Environment Information
         run: npx envinfo
-      - run: npm install -g cmake-js@5.3.2
+      - run: npm install -g cmake-js@6.3.2
       - run: npm install
       - name: Environment Information
         run: npx envinfo

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         node-version: [14.x, 16.x, 18.x]
-        operating-system: [ubuntu-latest, windows-latest, macos-latest]
+        operating-system: [ubuntu-latest, windows-2019, macos-latest]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -10,7 +10,7 @@ jobs:
     container: node
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
       - run: npx envinfo


### PR DESCRIPTION
This PR changes versions of components used in CI to the latest available:
-  node-version: [12.18.0, 14.x, 16.x] -> [14.x, 16.x, 18.x] _(version 12 is not supported anymore)_
- actions/checkout@v2 -> actions/checkout@v3
- actions/setup-node@v1 -> actions/setup-node@v3
- cmake-js@5.3.2 -> cmake-js@6.3.2