### PR TITLE
Fixed build with newer Node.js versions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
         operating-system: [ubuntu-latest, windows-2019, macos-latest]
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+build_with_cmake/
 node_modules/
 Debug/
 Release/

--- a/1_hello_world/nan/hello.cc
+++ b/1_hello_world/nan/hello.cc
@@ -5,7 +5,8 @@ void Method(const Nan::FunctionCallbackInfo<v8::Value>& info) {
 }
 
 void Init(v8::Local<v8::Object> exports) {
-  v8::Local<v8::Context> context = exports->CreationContext();
+  v8::Local<v8::Context> context =
+      exports->GetCreationContext().ToLocalChecked();
   exports->Set(context,
                Nan::New("hello").ToLocalChecked(),
                Nan::New<v8::FunctionTemplate>(Method)

--- a/2_function_arguments/nan/addon.cc
+++ b/2_function_arguments/nan/addon.cc
@@ -21,7 +21,8 @@ void Add(const Nan::FunctionCallbackInfo<v8::Value>& info) {
 }
 
 void Init(v8::Local<v8::Object> exports) {
-  v8::Local<v8::Context> context = exports->CreationContext();
+  v8::Local<v8::Context> context =
+      exports->GetCreationContext().ToLocalChecked();
   exports->Set(context,
                Nan::New("add").ToLocalChecked(),
                Nan::New<v8::FunctionTemplate>(Add)

--- a/4_object_factory/nan/addon.cc
+++ b/4_object_factory/nan/addon.cc
@@ -11,7 +11,8 @@ void CreateObject(const Nan::FunctionCallbackInfo<v8::Value>& info) {
 }
 
 void Init(v8::Local<v8::Object> exports, v8::Local<v8::Object> module) {
-  v8::Local<v8::Context> context = exports->CreationContext();
+  v8::Local<v8::Context> context =
+      exports->GetCreationContext().ToLocalChecked();
   module->Set(context,
               Nan::New("exports").ToLocalChecked(),
               Nan::New<v8::FunctionTemplate>(CreateObject)

--- a/6_object_wrap/nan/myobject.cc
+++ b/6_object_wrap/nan/myobject.cc
@@ -7,7 +7,8 @@ MyObject::MyObject(double value) : value_(value) {}
 MyObject::~MyObject() {}
 
 void MyObject::Init(v8::Local<v8::Object> exports) {
-  v8::Local<v8::Context> context = exports->CreationContext();
+  v8::Local<v8::Context> context =
+      exports->GetCreationContext().ToLocalChecked();
   Nan::HandleScope scope;
 
   // Prepare constructor template

--- a/7_factory_wrap/nan/addon.cc
+++ b/7_factory_wrap/nan/addon.cc
@@ -6,7 +6,8 @@ void CreateObject(const Nan::FunctionCallbackInfo<v8::Value>& info) {
 }
 
 void InitAll(v8::Local<v8::Object> exports, v8::Local<v8::Object> module) {
-  v8::Local<v8::Context> context = exports->CreationContext();
+  v8::Local<v8::Context> context =
+      exports->GetCreationContext().ToLocalChecked();
 
   Nan::HandleScope scope;
 

--- a/8_passing_wrapped/nan/addon.cc
+++ b/8_passing_wrapped/nan/addon.cc
@@ -19,7 +19,8 @@ void Add(const Nan::FunctionCallbackInfo<v8::Value>& info) {
 }
 
 void InitAll(v8::Local<v8::Object> exports) {
-  v8::Local<v8::Context> context = exports->CreationContext();
+  v8::Local<v8::Context> context =
+      exports->GetCreationContext().ToLocalChecked();
 
   MyObject::Init();
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "chalk": "^3.0.0",
     "clang-format": "^1.4.0",
+    "cmake-js": "^7.1.1",
     "semver": "^7.1.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "chalk": "^3.0.0",
     "clang-format": "^1.4.0",
-    "cmake-js": "^7.1.1", 
+    "cmake-js": "^7.1.1",
     "semver": "^7.1.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "chalk": "^3.0.0",
     "clang-format": "^1.4.0",
-    "cmake-js": "^7.1.1",
+    "cmake-js": "^7.1.1", 
     "semver": "^7.1.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixed build with newer Node.js versions, as `CreationContext` was deprecated for some versions of v8 and is now removed.

Added missing dependency "cmake-js", as `yarn test` fails without it.