### PR TITLE
no index.js exists in tsfn-test, and tsfn_object_wrap.js never exists…

### DIFF
--- a/src/6-threadsafe-function/thread_safe_function_with_object_wrap/node-addon-api/package.json
+++ b/src/6-threadsafe-function/thread_safe_function_with_object_wrap/node-addon-api/package.json
@@ -2,10 +2,12 @@
   "name": "tsfn-test",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
   "author": "",
   "dependencies": {
     "bindings": "*",
     "node-addon-api": "^7.0.0"
+  },
+  "scripts": {
+    "looptest": "node tsfn_object_wrap.js"
   }
 }


### PR DESCRIPTION
no index.js exists in tsfn-test that cause an error in the main test file.

a `tsfn_object_wrap.js` exists, but do not exist.

by adding a script named loopscript, the test script is still available via a `npm run` and do not cause an error to the main test script.
