### PR TITLE
unify 1-getting-started/6_object_wrap samples

### DIFF
--- a/src/1-getting-started/6_object_wrap/nan/addon.js
+++ b/src/1-getting-started/6_object_wrap/nan/addon.js
@@ -5,9 +5,16 @@ console.log( obj.plusOne() ); // 11
 console.log( obj.plusOne() ); // 12
 console.log( obj.plusOne() ); // 13
 
-console.log( obj.multiply().value() ); // 13
-console.log( obj.multiply(10).value() ); // 130
+console.log( obj.multiply().value ); // 13
+console.log( obj.multiply().getValue() ); // 13
+var multiplyed = obj.multiply(10);
+console.log( multiplyed.value ); // 130
+console.log( multiplyed.getValue() ); // 130
 
 var newobj = obj.multiply(-1);
-console.log( newobj.value() ); // -13
+console.log( newobj.getValue() ); // -13
 console.log( obj === newobj ); // false
+
+// use the setter
+obj.value = 99;
+console.log(obj.getValue()); // 99

--- a/src/1-getting-started/6_object_wrap/nan/myobject.cc
+++ b/src/1-getting-started/6_object_wrap/nan/myobject.cc
@@ -15,9 +15,12 @@ void MyObject::Init(v8::Local<v8::Object> exports) {
   v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
   tpl->SetClassName(Nan::New("MyObject").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
-
-  // Prototype
-  Nan::SetPrototypeMethod(tpl, "value", GetValue);
+  // define a filed with getter and setter
+  Nan::SetAccessor(tpl->InstanceTemplate(),
+                   Nan::New("value").ToLocalChecked(),
+                   GetValueAcc,
+                   SetValueAcc);
+  Nan::SetPrototypeMethod(tpl, "getValue", GetValue);
   Nan::SetPrototypeMethod(tpl, "plusOne", PlusOne);
   Nan::SetPrototypeMethod(tpl, "multiply", Multiply);
 
@@ -44,6 +47,24 @@ void MyObject::New(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     info.GetReturnValue().Set(
         cons->NewInstance(context, argc, argv).ToLocalChecked());
   }
+}
+/**
+ * Nan Property Getter
+ */
+void MyObject::GetValueAcc(v8::Local<v8::String> property,
+                           const Nan::PropertyCallbackInfo<v8::Value>& info) {
+  MyObject* obj = ObjectWrap::Unwrap<MyObject>(info.Holder());
+  info.GetReturnValue().Set(Nan::New(obj->value_));
+}
+/**
+ * Nan Property Setter
+ */
+void MyObject::SetValueAcc(v8::Local<v8::String> property,
+                           v8::Local<v8::Value> value,
+                           const Nan::PropertyCallbackInfo<void>& info) {
+  MyObject* obj = ObjectWrap::Unwrap<MyObject>(info.Holder());
+  obj->value_ =
+      value->NumberValue(info.GetIsolate()->GetCurrentContext()).FromJust();
 }
 
 void MyObject::GetValue(const Nan::FunctionCallbackInfo<v8::Value>& info) {

--- a/src/1-getting-started/6_object_wrap/nan/myobject.h
+++ b/src/1-getting-started/6_object_wrap/nan/myobject.h
@@ -12,6 +12,12 @@ class MyObject : public Nan::ObjectWrap {
   ~MyObject();
 
   static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static void GetValueAcc(v8::Local<v8::String> property,
+                          const Nan::PropertyCallbackInfo<v8::Value>& info);
+  static void SetValueAcc(v8::Local<v8::String> property,
+                          v8::Local<v8::Value> value,
+                          const Nan::PropertyCallbackInfo<void>& info);
+
   static void GetValue(const Nan::FunctionCallbackInfo<v8::Value>& info);
   static void PlusOne(const Nan::FunctionCallbackInfo<v8::Value>& info);
   static void Multiply(const Nan::FunctionCallbackInfo<v8::Value>& info);

--- a/src/1-getting-started/6_object_wrap/napi/addon.js
+++ b/src/1-getting-started/6_object_wrap/napi/addon.js
@@ -6,8 +6,15 @@ console.log( obj.plusOne() ); // 12
 console.log( obj.plusOne() ); // 13
 
 console.log( obj.multiply().value ); // 13
-console.log( obj.multiply(10).value ); // 130
+console.log( obj.multiply().getValue() ); // 13
+var multiplyed = obj.multiply(10);
+console.log( multiplyed.value ); // 130
+console.log( multiplyed.getValue() ); // 130
 
 var newobj = obj.multiply(-1);
-console.log( newobj.value ); // -13
+console.log( newobj.getValue() ); // -13
 console.log( obj === newobj ); // false
+
+// use the setter
+obj.value = 99;
+console.log(obj.getValue()); // 99

--- a/src/1-getting-started/6_object_wrap/napi/myobject.cc
+++ b/src/1-getting-started/6_object_wrap/napi/myobject.cc
@@ -21,13 +21,14 @@ napi_value MyObject::Init(napi_env env, napi_value exports) {
   napi_status status;
   napi_property_descriptor properties[] = {
       {"value", 0, 0, GetValue, SetValue, 0, napi_default, 0},
+      DECLARE_NAPI_METHOD("getValue", GetValue),
       DECLARE_NAPI_METHOD("plusOne", PlusOne),
       DECLARE_NAPI_METHOD("multiply", Multiply),
   };
 
   napi_value cons;
   status = napi_define_class(
-      env, "MyObject", NAPI_AUTO_LENGTH, New, nullptr, 3, properties, &cons);
+      env, "MyObject", NAPI_AUTO_LENGTH, New, nullptr, 4, properties, &cons);
   assert(status == napi_ok);
 
   // We will need the constructor `cons` later during the life cycle of the

--- a/src/1-getting-started/6_object_wrap/node-addon-api/addon.js
+++ b/src/1-getting-started/6_object_wrap/node-addon-api/addon.js
@@ -5,9 +5,16 @@ console.log( obj.plusOne() ); // 11
 console.log( obj.plusOne() ); // 12
 console.log( obj.plusOne() ); // 13
 
-console.log( obj.multiply().value() ); // 13
-console.log( obj.multiply(10).value() ); // 130
+console.log( obj.multiply().value ); // 13
+console.log( obj.multiply().getValue() ); // 13
+var multiplyed = obj.multiply(10);
+console.log( multiplyed.value ); // 130
+console.log( multiplyed.getValue() ); // 130
 
 var newobj = obj.multiply(-1);
-console.log( newobj.value() ); // -13
+console.log( newobj.getValue() ); // -13
 console.log( obj === newobj ); // false
+
+// use the setter
+obj.value = 99;
+console.log(obj.getValue()); // 99

--- a/src/1-getting-started/6_object_wrap/node-addon-api/myobject.cc
+++ b/src/1-getting-started/6_object_wrap/node-addon-api/myobject.cc
@@ -1,12 +1,13 @@
 #include "myobject.h"
 
 Napi::Object MyObject::Init(Napi::Env env, Napi::Object exports) {
-  Napi::Function func =
-      DefineClass(env,
-                  "MyObject",
-                  {InstanceMethod("plusOne", &MyObject::PlusOne),
-                   InstanceMethod("value", &MyObject::GetValue),
-                   InstanceMethod("multiply", &MyObject::Multiply)});
+  Napi::Function func = DefineClass(
+      env,
+      "MyObject",
+      {InstanceMethod("plusOne", &MyObject::PlusOne),
+       InstanceMethod("getValue", &MyObject::GetValue),
+       InstanceAccessor("value", &MyObject::GetValue, &MyObject::SetValue),
+       InstanceMethod("multiply", &MyObject::Multiply)});
 
   Napi::FunctionReference* constructor = new Napi::FunctionReference();
   *constructor = Napi::Persistent(func);
@@ -35,6 +36,19 @@ Napi::Value MyObject::GetValue(const Napi::CallbackInfo& info) {
   double num = this->value_;
 
   return Napi::Number::New(info.Env(), num);
+}
+
+void MyObject::SetValue(const Napi::CallbackInfo& info,
+                        const Napi::Value& value) {
+  Napi::Env env = info.Env();
+
+  if (!value.IsNumber()) {
+    Napi::TypeError::New(env, "Number expected").ThrowAsJavaScriptException();
+    return;
+  }
+
+  Napi::Number num = value.As<Napi::Number>();
+  this->value_ = num.DoubleValue();
 }
 
 Napi::Value MyObject::PlusOne(const Napi::CallbackInfo& info) {

--- a/src/1-getting-started/6_object_wrap/node-addon-api/myobject.h
+++ b/src/1-getting-started/6_object_wrap/node-addon-api/myobject.h
@@ -10,6 +10,7 @@ class MyObject : public Napi::ObjectWrap<MyObject> {
 
  private:
   Napi::Value GetValue(const Napi::CallbackInfo& info);
+  void SetValue(const Napi::CallbackInfo& info, const Napi::Value& value);
   Napi::Value PlusOne(const Napi::CallbackInfo& info);
   Napi::Value Multiply(const Napi::CallbackInfo& info);
 


### PR DESCRIPTION
The 3 example in 1-getting-started/6_object_wrap  do not implement the same addon.

- `Nan` implement value() as a function
- `Napi` implement value as a field
- `node-addon-api` implement value() as a function

this PR implement value as a Read and Write field and add a getValue() as a function.

the 2 accessor (set and set) and the getter are now called in the `addon.js`.

the 3 `addon.js` files  are now the same.


> note:
> the NaN::InstanceAccessor wasn't use in any example before this PR.
