### PR TITLE
Added an example with multiple object exports

### DIFF
--- a/src/1-getting-started/8_multiple_object_exports/addon.cc
+++ b/src/1-getting-started/8_multiple_object_exports/addon.cc
@@ -1,0 +1,17 @@
+#include "myobject-napi.h"
+#include "otherobject-napi.h"
+
+Napi::Object init(Napi::Env env, Napi::Object exports) {
+  Napi::ObjectReference *data = new Napi::ObjectReference();
+  
+  *data = Napi::Reference<Napi::Object>::New(Napi::Object::New(env), 1);
+  
+  env.SetInstanceData(data);
+    
+  MyObjectNapi::init(env, exports);
+  OtherObjectNapi::init(env, exports);
+  
+  return exports;
+}
+
+NODE_API_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/src/1-getting-started/8_multiple_object_exports/addon.js
+++ b/src/1-getting-started/8_multiple_object_exports/addon.js
@@ -1,0 +1,15 @@
+const addon = require('bindings')('addon')
+
+const obj = new addon.MyObject(5)
+
+obj.multiply(3)
+obj.plusOne()
+
+console.log(obj.value())
+
+const other = new addon.OtherObject("Hello, ")
+
+other.multiply(3)
+other.append("NAPI!")
+
+console.log(other.value())

--- a/src/1-getting-started/8_multiple_object_exports/binding.gyp
+++ b/src/1-getting-started/8_multiple_object_exports/binding.gyp
@@ -1,0 +1,19 @@
+{
+  "targets": [
+    {
+      # myModule is the name of your native addon
+      "target_name": "addon",
+      "sources": [
+        "addon.cc",
+        "myobject-napi.cc",
+        "myobject.cc",
+        "otherobject-napi.cc",
+        "otherobject.cc"
+      ],
+      "dependencies": [
+        "<!(node -p \"require('node-addon-api').targets\"):node_addon_api_except_all"
+      ]
+    }
+  ]
+}
+

--- a/src/1-getting-started/8_multiple_object_exports/myobject-napi.cc
+++ b/src/1-getting-started/8_multiple_object_exports/myobject-napi.cc
@@ -1,0 +1,38 @@
+#include "myobject-napi.h"
+
+MyObjectNapi::MyObjectNapi(const Napi::CallbackInfo& info) : Napi::ObjectWrap<MyObjectNapi>(info) {
+  if ( info.Length() > 0 && info[0].IsNumber() )
+    _nativeMyObject = std::make_shared<MyObject>(info[0].As<Napi::Number>().DoubleValue());
+  else
+    _nativeMyObject = std::make_shared<MyObject>(0);
+};
+
+void MyObjectNapi::init(Napi::Env env, Napi::Object exports) {
+  Napi::Function func = DefineClass(env, "MyObjectNapi", {
+    InstanceMethod("multiply", &MyObjectNapi::multiply),
+    InstanceMethod("plusOne", &MyObjectNapi::plusOne),
+    InstanceMethod("value", &MyObjectNapi::value)
+  });
+  
+  exports.Set("MyObject", func);
+}
+
+Napi::Value MyObjectNapi::multiply(const Napi::CallbackInfo& info) {
+  if ( info.Length() < 1 || !info[0].IsNumber() )
+    throw Napi::Error::New(info.Env(), "Invalid argument");
+    
+  return Napi::Number::New(info.Env(), _nativeMyObject->multiply(info[0].As<Napi::Number>().DoubleValue()));
+}
+
+Napi::Value MyObjectNapi::plusOne(const Napi::CallbackInfo& info) {
+  return Napi::Number::New(info.Env(), _nativeMyObject->plusOne());
+}
+
+Napi::Value MyObjectNapi::value(const Napi::CallbackInfo& info) {
+  if ( info.Length() == 0 )
+    return Napi::Number::New(info.Env(), _nativeMyObject->value());
+  
+  _nativeMyObject->value(info[0].As<Napi::Number>().DoubleValue());
+  
+  return info.Env().Null();
+}

--- a/src/1-getting-started/8_multiple_object_exports/myobject-napi.h
+++ b/src/1-getting-started/8_multiple_object_exports/myobject-napi.h
@@ -1,0 +1,21 @@
+#ifndef MYOBJECT_NAPI_H
+#define MYOBJECT_NAPI_H
+
+#include <memory>
+#include <napi.h>
+
+#include "myobject.h"
+
+class MyObjectNapi : public Napi::ObjectWrap<MyObjectNapi> {
+  public:
+    MyObjectNapi(const Napi::CallbackInfo& info);
+    static void init(Napi::Env env, Napi::Object exports);
+    Napi::Value multiply(const Napi::CallbackInfo& info);
+    Napi::Value plusOne(const Napi::CallbackInfo& info);
+    Napi::Value value(const Napi::CallbackInfo& info);
+    
+  private:
+    std::shared_ptr<MyObject> _nativeMyObject;
+};
+
+#endif

--- a/src/1-getting-started/8_multiple_object_exports/myobject.cc
+++ b/src/1-getting-started/8_multiple_object_exports/myobject.cc
@@ -1,0 +1,25 @@
+#include "myobject.h"
+
+MyObject::MyObject(double value) {
+  _value = value;
+}
+
+double MyObject::multiply(double value) {
+  _value *= value;
+  
+  return _value;
+}
+
+double MyObject::plusOne() {
+  _value++;
+  
+  return _value;
+}
+
+double MyObject::value() {
+  return _value;
+}
+
+void MyObject::value(double value) {
+  _value = value;
+}

--- a/src/1-getting-started/8_multiple_object_exports/myobject.h
+++ b/src/1-getting-started/8_multiple_object_exports/myobject.h
@@ -1,0 +1,18 @@
+#ifndef MYOBJECT_H
+#define MYOBJECT_H
+
+#include <napi.h>
+
+class MyObject {
+  public:
+    MyObject(double value);
+    double multiply(double value);
+    double plusOne();
+    double value();
+    void value(double value);
+    
+  private:
+    double _value;
+};
+
+#endif

--- a/src/1-getting-started/8_multiple_object_exports/otherobject-napi.cc
+++ b/src/1-getting-started/8_multiple_object_exports/otherobject-napi.cc
@@ -1,0 +1,41 @@
+#include "otherobject-napi.h"
+
+OtherObjectNapi::OtherObjectNapi(const Napi::CallbackInfo& info) : Napi::ObjectWrap<OtherObjectNapi>(info) {
+  if ( info.Length() > 0 && info[0].IsString() )
+    _nativeOtherObject = std::make_shared<OtherObject>(info[0].As<Napi::String>().Utf8Value());
+  else
+    _nativeOtherObject = std::make_shared<OtherObject>("");
+};
+
+void OtherObjectNapi::init(Napi::Env env, Napi::Object exports) {
+  Napi::Function func = DefineClass(env, "OtherObjectNapi", {
+    InstanceMethod("multiply", &OtherObjectNapi::multiply),
+    InstanceMethod("append", &OtherObjectNapi::append),
+    InstanceMethod("value", &OtherObjectNapi::value)
+  });
+  
+  exports.Set("OtherObject", func);
+}
+
+Napi::Value OtherObjectNapi::multiply(const Napi::CallbackInfo& info) {
+  if ( info.Length() < 1 || !info[0].IsNumber() )
+    throw Napi::Error::New(info.Env(), "Invalid argument");
+    
+  return Napi::String::New(info.Env(), _nativeOtherObject->multiply(info[0].As<Napi::Number>().Int32Value()));
+}
+
+Napi::Value OtherObjectNapi::append(const Napi::CallbackInfo& info) {
+  if ( info.Length() < 1 || !info[0].IsString() )
+    throw Napi::Error::New(info.Env(), "Invalid argument");
+    
+  return Napi::String::New(info.Env(), _nativeOtherObject->append(info[0].As<Napi::String>().Utf8Value()));
+}
+
+Napi::Value OtherObjectNapi::value(const Napi::CallbackInfo& info) {
+  if ( info.Length() == 0 )
+    return Napi::String::New(info.Env(), _nativeOtherObject->value());
+  
+  _nativeOtherObject->value(info[0].As<Napi::String>().Utf8Value());
+  
+  return info.Env().Null();
+}

--- a/src/1-getting-started/8_multiple_object_exports/otherobject-napi.h
+++ b/src/1-getting-started/8_multiple_object_exports/otherobject-napi.h
@@ -1,0 +1,21 @@
+#ifndef OTHEROBJECT_NAPI_H
+#define OTHEROBJECT_NAPI_H
+
+#include <memory>
+#include <napi.h>
+
+#include "otherobject.h"
+
+class OtherObjectNapi : public Napi::ObjectWrap<OtherObjectNapi> {
+  public:
+    OtherObjectNapi(const Napi::CallbackInfo& info);
+    static void init(Napi::Env env, Napi::Object exports);
+    Napi::Value multiply(const Napi::CallbackInfo& info);
+    Napi::Value append(const Napi::CallbackInfo& info);
+    Napi::Value value(const Napi::CallbackInfo& info);
+    
+  private:
+    std::shared_ptr<OtherObject> _nativeOtherObject;
+};
+
+#endif

--- a/src/1-getting-started/8_multiple_object_exports/otherobject.cc
+++ b/src/1-getting-started/8_multiple_object_exports/otherobject.cc
@@ -1,0 +1,28 @@
+#include "otherobject.h"
+
+OtherObject::OtherObject(std::string value) {
+  _value = value;
+}
+
+std::string OtherObject::multiply(int value) {
+  std::string original = _value;
+  
+  for ( int i = 0; i < value; i++ )
+    _value += original;
+    
+  return _value;
+}
+
+std::string OtherObject::append(std::string value) {
+  _value += value;
+  
+  return _value;
+}
+
+std::string OtherObject::value() {
+  return _value;
+}
+
+void OtherObject::value(std::string value) {
+  _value = value;
+}

--- a/src/1-getting-started/8_multiple_object_exports/otherobject.h
+++ b/src/1-getting-started/8_multiple_object_exports/otherobject.h
@@ -1,0 +1,19 @@
+#ifndef OTHEROBJECT_H
+#define OTHEROBJECT_H
+
+#include <napi.h>
+#include <string>
+
+class OtherObject {
+  public:
+    OtherObject(std::string value);
+    std::string multiply(int value);
+    std::string append(std::string value);
+    std::string value();
+    void value(std::string value);
+    
+  private:
+    std::string _value;
+};
+
+#endif

--- a/src/1-getting-started/8_multiple_object_exports/package.json
+++ b/src/1-getting-started/8_multiple_object_exports/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "multiple",
+  "version": "0.0.0",
+  "description": "Node.js Addons Example #8",
+  "main": "addon.js",
+  "private": true,
+  "gypfile": true,
+  "engines": {
+    "node": "~10 >=10.20 || >=12.17"
+  },
+  "dependencies": {
+    "bindings": "~1.5.0",
+    "node-addon-api": "^8.1.0"
+  }
+}


### PR DESCRIPTION
The current examples only demonstrate how to export one class or function, and there have been requests for improvement, see #180 and #171.  After my second time having to get up to speed on how to do it for a project, I decided to make a quick example.  Please let me know if you’d like any changes.